### PR TITLE
Add 'like' and 'unlike' classes to like links

### DIFF
--- a/message/html/action/like.js
+++ b/message/html/action/like.js
@@ -13,21 +13,16 @@ exports.create = (api) => {
   return nest('message.html.action', function like (msg) {
     var id = api.keys.sync.id()
     var liked = computed([api.message.obs.likes(msg.key), id], doesLike)
-    var attributes = {
-      href: '#',
-      events: {
-        click: (ev) => {
-          if (liked()) {
-            publishLike(msg, false)
-          } else {
-            publishLike(msg, true)
-          }
-        }
-      }
-    }
-    return h('span', when(liked, 
-                          h('a.liked', attributes, 'Unlike'), 
-                          h('a.unliked', attributes, 'Like'))
+    return when(liked, 
+      h('a.unlike', {
+        href: '#',
+        'ev-click': () => publishLike(msg, false)
+      }, 'Unlike'),
+      h('a.like', {
+        href: '#',
+        'ev-click': () => publishLike(msg, true)
+      }, 'Like'),
+    )
   })
 
   function publishLike (msg, status = true) {

--- a/message/html/action/like.js
+++ b/message/html/action/like.js
@@ -13,7 +13,7 @@ exports.create = (api) => {
   return nest('message.html.action', function like (msg) {
     var id = api.keys.sync.id()
     var liked = computed([api.message.obs.likes(msg.key), id], doesLike)
-    return h('a', {
+    var attributes = {
       href: '#',
       events: {
         click: (ev) => {
@@ -24,7 +24,8 @@ exports.create = (api) => {
           }
         }
       }
-    }, when(liked, 'Unlike', 'Like'))
+    }
+    return h('span', when(liked, h('a.liked', attributes, 'Unlike'), h('a.unliked', attributes, 'Like'))
   })
 
   function publishLike (msg, status = true) {

--- a/message/html/action/like.js
+++ b/message/html/action/like.js
@@ -25,7 +25,9 @@ exports.create = (api) => {
         }
       }
     }
-    return h('span', when(liked, h('a.liked', attributes, 'Unlike'), h('a.unliked', attributes, 'Like'))
+    return h('span', when(liked, 
+                          h('a.liked', attributes, 'Unlike'), 
+                          h('a.unliked', attributes, 'Like'))
   })
 
   function publishLike (msg, status = true) {

--- a/message/html/action/like.js
+++ b/message/html/action/like.js
@@ -21,7 +21,7 @@ exports.create = (api) => {
       h('a.like', {
         href: '#',
         'ev-click': () => publishLike(msg, true)
-      }, 'Like'),
+      }, 'Like')
     )
   })
 


### PR DESCRIPTION
This is part of my master plan to bring back the [dig icon](http://fontawesome.io/icon/hand-peace-o/) from the old patchwork-classic. It's a styling choice to have such an icon, so we need a class that lets us know:

1. This is a like button
2. Whether the thing is liked or not.

Then we can add any icons we want in CSS.

I've never used Mutant before, so this should be inspected by someone who has.