### PR TITLE
rename `channel` to `renderChannel`, so no const conflict

### DIFF
--- a/message/html/meta/channel.js
+++ b/message/html/meta/channel.js
@@ -4,7 +4,7 @@ const nest = require('depnest')
 exports.gives = nest('message.html.meta')
 
 exports.create = (api) => {
-  return nest('message.html.meta', function channel (msg) {
+  return nest('message.html.meta', function renderChannel (msg) {
     const { channel } = msg.value.content
     if (channel) return h('a.channel', {href: `#${channel}`}, [`#${channel}`])
   })


### PR DESCRIPTION
fixes:

```
SyntaxError: /.../patchcore/message/html/meta/channel.js: "channel" is read-only
   5 | 
   6 | exports.create = (api) => {
>  7 |   return nest('message.html.meta', function channel (msg) {
     |                                    ^
   8 |     const { channel } = msg.value.content
   9 |     if (channel) return h('a.channel', {href: `#${channel}`}, [`#${channel}`])
  10 |   })
```

needed to `browserify` `patchcore`: https://github.com/ssbc/patchbay/pull/102