### PR TITLE
don't throw sbot.gossip.peers error

### DIFF
--- a/sbot.js
+++ b/sbot.js
@@ -226,7 +226,7 @@ exports.create = function (api) {
   function refreshPeers () {
     if (sbot) {
       sbot.gossip.peers((err, peers) => {
-        if (err) throw console.log(err)
+        if (err) return console.error(err)
         connectedPeers.set(peers.filter(x => x.state === 'connected').map(x => x.key))
         localPeers.set(peers.filter(x => x.source === 'local').map(x => x.key))
       })


### PR DESCRIPTION
otherwise am getting the following error in browser:

```
"Error: method:gossip,peers is not on whitelist
    at Function.perms.pre (/home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/muxrpc/permissions.js:88:14)
    at Object.<anonymous> (/home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/muxrpc/local-api.js:35:21)
    at Object.PacketStream.request (/home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/muxrpc/stream.js:46:17)
    at PacketStream._onrequest (/home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/packet-stream/index.js:149:17)
    at PacketStream.write (/home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/packet-stream/index.js:122:41)
    at /home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/muxrpc/pull-weird.js:56:15
    at /home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/pull-stream/sinks/drain.js:24:37
    at /home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/pull-stream/throughs/filter.js:17:11
    at Object.cb (/home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/packet-stream-codec/index.js:107:11)
    at drain (/home/dinosaur/.ssb/node_modules/ssb-ws/node_modules/pull-reader/index.js:39:14)"
```

i'm not sure why, because my manifest includes:

```
  "gossip": {
    "peers": "sync"
  }
}
```