### PR TITLE
branch should show whether the thread has branched

### DIFF
--- a/feed/obs/thread.js
+++ b/feed/obs/thread.js
@@ -47,8 +47,9 @@ exports.create = function (api) {
     var result = {
       messages,
       lastId: computed(messages, (messages) => {
-        var last = messages[messages.length - 1]
-        if (last) return last.key
+        var branches = sort.heads(messages)
+        if(branches.length <= 1) branches = branches[0]
+        return branches
       }),
       rootId: computed(messages, (messages) => {
         if (branch && messages.length) {


### PR DESCRIPTION
This change makes it so _if_ there was a concurrent comment on a thread (say, several people respond while offline) then that is recorded. This was the behavior in patchbay classic. patchwork and patchbay@7 both do not do anything with the branch except for put it in the message, so this shouldn't break anything, but updating them to use patchcore with this merged will have the correct behavior.

We'll need to have this behavior so we can have out of order repiles that work as you would expect, because you'll be able to trace the whole thread backwards from the reply you see, otherwise, you'll tend to get different views of the thread, which may disadvantage people who tend to use ssb while offline.
