### PR TITLE
make `contact` and `about` somewhat lazier

### DIFF
--- a/contact/obs.js
+++ b/contact/obs.js
@@ -16,6 +16,7 @@ exports.gives = nest({
 exports.create = function (api) {
   var cacheLoading = false
   var cache = {}
+  var state = {}
   var sync = Value(false)
 
   return nest({
@@ -49,7 +50,9 @@ exports.create = function (api) {
       pull.drain(item => {
         for (var target in item) {
           if (ref.isFeed(target)) {
-            get(target).push(item[target])
+            state[target] = item[target]
+            if(cache[target])
+              get(target).push(item[target])
           }
         }
 
@@ -68,6 +71,7 @@ exports.create = function (api) {
     }
     if (!cache[id]) {
       cache[id] = Contact(api, id, sync)
+      cache[id].push(state[id])
     }
     return cache[id]
   }
@@ -120,4 +124,7 @@ function getIds (state, key, compare) {
 function isContact (msg) {
   return msg.value && msg.value.content && msg.value.content.type === 'contact'
 }
+
+
+
 


### PR DESCRIPTION
This still leaves something to be desired, but it does save a lot of work.

before adding this:
![load_unlazy2](https://user-images.githubusercontent.com/259374/27315915-a653f1fa-55d0-11e7-97a9-2d466208359a.png)
after adding this
![load_lazy](https://user-images.githubusercontent.com/259374/27315923-aded5db6-55d0-11e7-98d8-9606ae4c68b7.png)

This is just loading patchbay and letting it sit there for 30 seconds.

This small change seems to reduce the time spent scripting somewhat, although there is still too much. It makes only a small difference to, ram though.

It's still replicating the view in a very ad hoc way, and there is also some bits in patchbay using the old pattern... but it is a step in the right direction.