### PR TITLE
Add 'relatedMessages' to the sbot depject exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchcore",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "minimal core for ssb clients",
   "main": "index.js",
   "scripts": {

--- a/sbot.js
+++ b/sbot.js
@@ -22,6 +22,7 @@ exports.gives = {
     },
     async: {
       get: true,
+      relatedMessages: true,
       publish: true,
       addBlob: true,
       gossipConnect: true
@@ -135,6 +136,18 @@ exports.create = function (api) {
               runHooks({key, value})
               cb(null, value)
             })
+          }
+        }),
+        relatedMessages: rec.async(function(key, cb) {
+          if (typeof cb !== 'function') {
+            throw new Error('cb must be function')
+          }
+          else {
+            sbot.relatedMessages(key, function(err, value) {
+              if (err) return cb(err)
+              runHooks({key, value})
+              cb(null, value)
+            });
           }
         }),
         publish: rec.async((content, cb) => {


### PR DESCRIPTION
I'm looking to play around with injecting ssb-chess (https://www.github.com/happy0/ssb-chess) into patchbay as a plugin.

ssb-chess uses relatedMessages, so I thought I'd expose that from the sbot 'gives' list.

Would you guys be okay with exposing this function?

**Note**: I haven't been able to test this successfully yet as when I start patchbay (which I modified to call through to my async.relatedMessages) I get the following errors:

TypeError: Cannot read property 'stream' of undefined
    at api.sbot.pull.stream.sbot (/home/happy0/projects/patchcore/contact/obs.js:54:49)
    at /home/happy0/projects/patchcore/sbot.js:242:28
    at Array.watch (/home/happy0/projects/patchcore/node_modules/mutant/once-true.js:8:7)
    at Function.Observable.observable.set (/home/happy0/projects/patchcore/node_modules/mutant/value.js:12:25)
    at /home/happy0/projects/patchcore/sbot.js:76:18
    at /home/happy0/projects/patchcore/node_modules/ssb-client/index.js:105:5
    at next (/home/happy0/projects/patchcore/node_modules/multiserver/compose.js:28:14)
    at /home/happy0/projects/patchcore/node_modules/multiserver/compose.js:34:9
    at _cb (/home/happy0/projects/patchcore/node_modules/multiserver/plugins/shs.js:31:11)
    at /home/happy0/projects/patchcore/node_modules/secret-handshake/protocol.js:120:7

I'll let you know when I've tested this Pull Request (if you want to expose relatedMessages.)