### PR TITLE
introduce about.sync.shortFeedId for the id slice

### DIFF
--- a/about/obs.js
+++ b/about/obs.js
@@ -8,6 +8,7 @@ var fallbackImageUrl = 'data:image/gif;base64,R0lGODlhAQABAPAAAP///wAAACH5BAEAAA
 exports.needs = nest({
   'sbot.pull.stream': 'first',
   'blob.sync.url': 'first',
+  'about.sync.shortFeedId': 'first',
   'keys.sync.id': 'first'
 })
 
@@ -35,7 +36,7 @@ exports.create = function (api) {
   return nest({
     'about.obs': {
       // quick helpers, probably should deprecate!
-      name: (id) => socialValue(id, 'name', id.slice(1, 10)),
+      name: (id) => socialValue(id, 'name', api.about.sync.shortFeedId(id)),
       description: (id) => socialValue(id, 'description'),
       image: (id) => socialValue(id, 'image'),
       names: (id) => groupedValues(id, 'name'),

--- a/about/sync.js
+++ b/about/sync.js
@@ -1,0 +1,9 @@
+var nest = require('depnest');
+
+exports.gives = nest('about.sync.shortFeedId');
+
+exports.create = function (api) {
+  return nest('about.sync.shortFeedId', function (id) {
+    return id.slice(1, 10);
+  });
+};


### PR DESCRIPTION
For the mobile client, I wanted to customize what the short feed id is for each account. Patchcore and the patch ecosystem use `p4eesYq8w` for `@p4eesYq8w9lx51OISplvZPiqblpsFZP0IBAoliYaazw=.ed25519`, but I wanted `@p4eesYq8w...` instead. This PR allows us to customize that opinion, introducing `about.sync.shortFeedId`.