### PR TITLE
add blocking calls and observeables

### DIFF
--- a/contact/async.js
+++ b/contact/async.js
@@ -10,12 +10,12 @@ exports.needs = nest({
 })
 
 exports.gives = nest({
-  'contact.async': ['follow', 'unfollow', 'followerOf']
+  'contact.async': ['follow', 'unfollow', 'followerOf', 'block', 'unblock']
 })
 
 exports.create = function (api) {
   return nest({
-    'contact.async': {follow, unfollow, followerOf}
+    'contact.async': {follow, unfollow, followerOf, block, unblock}
   })
 
   function followerOf (source, dest, cb) {
@@ -39,8 +39,24 @@ exports.create = function (api) {
       following: false
     }, cb)
   }
+
+  function block (id, cb) {
+    if (!ref.isFeed(id)) throw new Error('a feed id must be specified')
+    api.sbot.async.publish({
+      type: 'contact',
+      contact: id,
+      blocking: true
+    }, cb)
+  }
+
+  function unblock (id, cb) {
+    if (!ref.isFeed(id)) throw new Error('a feed id must be specified')
+    api.sbot.async.publish({
+      type: 'contact',
+      contact: id,
+      blocking: false
+    }, cb)
+  }
+
 }
-
-
-
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2561,14 +2561,6 @@
         "pull-stream": "3.6.0"
       }
     },
-    "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-      "requires": {
-        "safe-buffer": "5.0.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2578,6 +2570,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "requires": {
+        "safe-buffer": "5.0.1"
       }
     },
     "strip-ansi": {


### PR DESCRIPTION
Extend the implementation of `contact.async` and `contact.obs` to enable mvp blocking

dependent on a PR to ssb-contacts 