### PR TITLE
Don't show posts of users you blocked

### DIFF
--- a/feed/obs/thread.js
+++ b/feed/obs/thread.js
@@ -8,7 +8,7 @@ exports.needs = nest({
   'sbot.async.get': 'first',
   'message.sync.unbox': 'first',
   'message.sync.root': 'first',
-  'message.sync.isBlocked': 'first',
+  'message.sync.isBlocked': 'first'
 })
 
 exports.gives = nest('feed.obs.thread')
@@ -19,7 +19,7 @@ exports.create = function (api) {
   function thread (rootId, { branch } = {}) {
     if (!ref.isLink(rootId)) throw new Error('an id must be specified')
     var sync = Value(false)
-    const { isBlocked, unbox, root } = message.sync
+    var { isBlocked, root } = api.message.sync
 
     var prepend = MutantArray()
     api.sbot.async.get(rootId, (err, value) => {
@@ -35,9 +35,7 @@ exports.create = function (api) {
     var replies = map(computed(backlinks, (msgs) => {
       return msgs.filter(msg => {
         const { type, branch } = msg.value.content
-        return type !== 'vote'
-          && !isBlocked(msg)
-          && (root(msg) === rootId || matchAny(branch, rootId))
+        return type !== 'vote' && !isBlocked(msg) && (root(msg) === rootId || matchAny(branch, rootId))
       })
     }), x => Value(x), {
       // avoid refresh of entire list when items added
@@ -91,7 +89,7 @@ exports.create = function (api) {
 
   function unboxIfNeeded (msg) {
     if (msg.value && typeof msg.value.content === 'string') {
-      return unbox(msg) || msg
+      return api.message.sync.unbox(msg) || msg
     } else {
       return msg
     }

--- a/feed/obs/thread.js
+++ b/feed/obs/thread.js
@@ -28,7 +28,7 @@ exports.create = function (api) {
       sync.set(true)
       if (!err) {
         var msg = unboxIfNeeded({key: rootId, value})
-        if (blocking().includes(msg.value.author)) return
+        if (blocking().includes(msg.value.author)) msg.isBlocked = true
         prepend.push(Value(msg))
       }
     })

--- a/feed/pull/mentions.js
+++ b/feed/pull/mentions.js
@@ -4,7 +4,9 @@ const pull = require('pull-stream')
 const ref = require('ssb-ref')
 
 exports.needs = nest({
-  'sbot.pull.backlinks': 'first'
+  'sbot.pull.backlinks': 'first',
+  'contact.obs.blocking': 'first',
+  'keys.sync.id': 'first'
 })
 
 exports.gives = nest('feed.pull.mentions')
@@ -29,7 +31,12 @@ exports.create = function (api) {
         ]
       })
 
-      return api.sbot.pull.backlinks(opts)
+      const blocking = api.contact.obs.blocking(api.keys.sync.id())
+
+      return pull(
+        api.sbot.pull.backlinks(opts),
+        pull.filter((msg) => !blocking().includes(msg.value.author))
+      )
     }
   })
 }

--- a/feed/pull/public.js
+++ b/feed/pull/public.js
@@ -1,13 +1,25 @@
 const nest = require('depnest')
+var pull = require('pull-stream')
 
 exports.gives = nest('feed.pull.public')
-exports.needs = nest('sbot.pull.feed', 'first')
+exports.needs = nest({
+  'sbot.pull.feed': 'first',
+  'contact.obs.blocking': 'first',
+  'keys.sync.id': 'first'
+})
+
 exports.create = function (api) {
   return nest('feed.pull.public', (opts) => {
     // handle last item passed in as lt
     opts.lt = (opts.lt && opts.lt.value)
       ? opts.lt.value.timestamp
       : opts.lt
-    return api.sbot.pull.feed(opts)
+
+    const blocking = api.contact.obs.blocking(api.keys.sync.id())
+
+    return pull(
+      api.sbot.pull.feed(opts),
+      pull.filter(msg => !blocking().includes(msg.value.author))
+    )
   })
 }

--- a/feed/pull/rollup.js
+++ b/feed/pull/rollup.js
@@ -85,7 +85,7 @@ exports.create = function (api) {
       // FILTER
       pull.filter(msg => msg && msg.value && !api.message.sync.root(msg)),
       pull.filter(rootFilter || (() => true)),
-      pull.filter(msg => !api.message.sync.isBlocked(msg))
+      pull.filter(msg => !api.message.sync.isBlocked(msg)),
 
       // ADD REPLIES
       pull.asyncMap((rootMessage, cb) => {
@@ -93,8 +93,7 @@ exports.create = function (api) {
         var backlinks = api.backlinks.obs.for(rootMessage.key)
         onceTrue(backlinks.sync, () => {
           var replies = resolve(backlinks).filter(msg => {
-            return api.message.sync.root(msg) === rootMessage.key
-              && !api.message.sync.isBlocked(msg)
+            return api.message.sync.root(msg) === rootMessage.key && !api.message.sync.isBlocked(msg)
           })
           cb(null, extend(rootMessage, { replies }))
         })

--- a/feed/pull/type.js
+++ b/feed/pull/type.js
@@ -1,8 +1,14 @@
 const nest = require('depnest')
 const extend = require('xtend')
+const pull = require('pull-stream')
 
 exports.gives = nest('feed.pull.type')
-exports.needs = nest('sbot.pull.messagesByType', 'first')
+exports.needs = nest({
+  'sbot.pull.messagesByType': 'first',
+  'contact.obs.blocking': 'first',
+  'keys.sync.id': 'first'
+})
+
 exports.create = function (api) {
   return nest('feed.pull.type', (type) => {
     if (typeof type !== 'string') throw new Error('a type must be specified')
@@ -14,7 +20,12 @@ exports.create = function (api) {
         lt: opts.lt && typeof opts.lt === 'object' ? opts.lt.timestamp : opts.lt
       })
 
-      return api.sbot.pull.messagesByType(opts)
+      const blocking = api.contact.obs.blocking(api.keys.sync.id())
+
+      return pull(
+        api.sbot.pull.messagesByType(opts),
+        pull.filter(msg => !blocking().includes(msg.value.author))
+      )
     }
   })
 }

--- a/message/html/render/post.js
+++ b/message/html/render/post.js
@@ -18,7 +18,7 @@ exports.create = function (api) {
     if (msg.value.content.type !== 'post') return
     var element = api.message.html.layout(msg, extend({
       title: messageTitle(msg),
-      content: messageContent(msg),
+      content: msg.isBlocked ? 'Content of a blocked user' : messageContent(msg),
       layout: 'default'
     }, opts))
 

--- a/message/html/render/post.js
+++ b/message/html/render/post.js
@@ -3,6 +3,8 @@ var nest = require('depnest')
 var extend = require('xtend')
 
 exports.needs = nest({
+  'contact.obs.blockers': 'first',
+  'keys.sync.id': 'first',
   'message.html': {
     decorate: 'reduce',
     layout: 'first',
@@ -14,8 +16,14 @@ exports.needs = nest({
 exports.gives = nest('message.html.render')
 
 exports.create = function (api) {
+  const myId = api.keys.sync.id()
+
   return nest('message.html.render', function renderMessage (msg, opts) {
     if (msg.value.content.type !== 'post') return
+
+    const blockers = api.contact.obs.blockers(msg.value.author)
+    if (blockers().includes(myId)) return
+
     var element = api.message.html.layout(msg, extend({
       title: messageTitle(msg),
       content: messageContent(msg),

--- a/message/html/render/post.js
+++ b/message/html/render/post.js
@@ -3,8 +3,6 @@ var nest = require('depnest')
 var extend = require('xtend')
 
 exports.needs = nest({
-  'contact.obs.blockers': 'first',
-  'keys.sync.id': 'first',
   'message.html': {
     decorate: 'reduce',
     layout: 'first',
@@ -16,14 +14,8 @@ exports.needs = nest({
 exports.gives = nest('message.html.render')
 
 exports.create = function (api) {
-  const myId = api.keys.sync.id()
-
   return nest('message.html.render', function renderMessage (msg, opts) {
     if (msg.value.content.type !== 'post') return
-
-    const blockers = api.contact.obs.blockers(msg.value.author)
-    if (blockers().includes(myId)) return
-
     var element = api.message.html.layout(msg, extend({
       title: messageTitle(msg),
       content: messageContent(msg),

--- a/message/sync/is-blocked.js
+++ b/message/sync/is-blocked.js
@@ -3,20 +3,18 @@ const nest = require('depnest')
 exports.gives = nest('message.sync.isBlocked')
 
 exports.needs = nest({
-  'contact.obs.blocking': 'first'
+  'contact.obs.blocking': 'first',
   'keys.sync.id': 'first'
 })
 
 exports.create = function (api) {
-  var _myBlocking
+  var cache = null
 
   return nest('message.sync.isBlocked', function isBlockedMessage (msg) {
-    if (!_myBlocking) {
-      const myKey = api.keys.sync.id()
-      _myBlocking = api.contact.obs.blocking(myKey) 
+    if (!cache) {
+      cache = api.contact.obs.blocking(api.keys.sync.id())
     }
 
-    return _myBlocking.includes(msg.value.author)
+    return cache().includes(msg.value.author)
   })
 }
-


### PR DESCRIPTION
I'm pretty excited about this! Thanks to @mixmix we can now block people, but things they have already posted will still be displayed. Even worse, you can't get rid of the blobs as they will be auto fetched if you view their messages again. This patch simple doesn't render posts for users you have blocked, you will still be able to see that a user posted something and at least in patchbay you can see the raw message, but the content won't be displayed by default. I think this is pretty much what people expect will happen if they block someone.