### PR TITLE
patch for `Don't show posts of users you blocked`

### DIFF
--- a/contact/obs.js
+++ b/contact/obs.js
@@ -4,7 +4,7 @@ var pull = require('pull-stream')
 var ref = require('ssb-ref')
 
 exports.needs = nest({
-  'sbot.pull.stream': 'first'
+  'sbot.pull.stream': 'first',
 })
 
 exports.gives = nest({

--- a/feed/pull/channel.js
+++ b/feed/pull/channel.js
@@ -5,8 +5,7 @@ var pull = require('pull-stream')
 exports.gives = nest('feed.pull.channel')
 exports.needs = nest({
   'sbot.pull.backlinks': 'first',
-  'contact.obs.blocking': 'first',
-  'keys.sync.id': 'first'
+  'message.sync.isBlocked': 'first',
 })
 
 exports.create = function (api) {
@@ -28,15 +27,13 @@ exports.create = function (api) {
         }
       }
 
-      const blocking = api.contact.obs.blocking(api.keys.sync.id())
-
       return pull(
         api.sbot.pull.backlinks(extend(opts, {
           query: [
             {$filter: filter}
           ]
         })),
-        pull.filter(msg => !blocking().includes(msg.value.author))
+        pull.filter(msg => !api.message.sync.isBlocked(msg))
       )
     }
   })

--- a/feed/pull/mentions.js
+++ b/feed/pull/mentions.js
@@ -5,8 +5,7 @@ const ref = require('ssb-ref')
 
 exports.needs = nest({
   'sbot.pull.backlinks': 'first',
-  'contact.obs.blocking': 'first',
-  'keys.sync.id': 'first'
+  'message.sync.isBlocked': 'first'
 })
 
 exports.gives = nest('feed.pull.mentions')
@@ -31,11 +30,9 @@ exports.create = function (api) {
         ]
       })
 
-      const blocking = api.contact.obs.blocking(api.keys.sync.id())
-
       return pull(
         api.sbot.pull.backlinks(opts),
-        pull.filter((msg) => !blocking().includes(msg.value.author))
+        pull.filter(msg => !api.message.sync.isBlocked(msg))
       )
     }
   })

--- a/feed/pull/public.js
+++ b/feed/pull/public.js
@@ -4,8 +4,7 @@ var pull = require('pull-stream')
 exports.gives = nest('feed.pull.public')
 exports.needs = nest({
   'sbot.pull.feed': 'first',
-  'contact.obs.blocking': 'first',
-  'keys.sync.id': 'first'
+  'message.sync.isBlocked': 'first',
 })
 
 exports.create = function (api) {
@@ -15,11 +14,9 @@ exports.create = function (api) {
       ? opts.lt.value.timestamp
       : opts.lt
 
-    const blocking = api.contact.obs.blocking(api.keys.sync.id())
-
     return pull(
       api.sbot.pull.feed(opts),
-      pull.filter(msg => !blocking().includes(msg.value.author))
+      pull.filter(msg => !api.message.sync.isBlocked(msg))
     )
   })
 }

--- a/feed/pull/type.js
+++ b/feed/pull/type.js
@@ -5,8 +5,7 @@ const pull = require('pull-stream')
 exports.gives = nest('feed.pull.type')
 exports.needs = nest({
   'sbot.pull.messagesByType': 'first',
-  'contact.obs.blocking': 'first',
-  'keys.sync.id': 'first'
+  'message.sync.isBlocked': 'first',
 })
 
 exports.create = function (api) {
@@ -20,11 +19,9 @@ exports.create = function (api) {
         lt: opts.lt && typeof opts.lt === 'object' ? opts.lt.timestamp : opts.lt
       })
 
-      const blocking = api.contact.obs.blocking(api.keys.sync.id())
-
       return pull(
         api.sbot.pull.messagesByType(opts),
-        pull.filter(msg => !blocking().includes(msg.value.author))
+        pull.filter(msg => !api.message.sync.isBlocked(msg))
       )
     }
   })

--- a/message/sync/isBlocked.js
+++ b/message/sync/isBlocked.js
@@ -1,0 +1,22 @@
+const nest = require('depnest')
+
+exports.gives = nest('message.sync.isBlocked')
+
+exports.needs = nest({
+  'contact.obs.blocking': 'first'
+  'keys.sync.id': 'first'
+})
+
+exports.create = function (api) {
+  var _myBlocking
+
+  return nest('message.sync.isBlocked', function isBlockedMessage (msg) {
+    if (!_myBlocking) {
+      const myKey = api.keys.sync.id()
+      _myBlocking = api.contact.obs.blocking(myKey) 
+    }
+
+    return _myBlocking.includes(msg.value.author)
+  })
+}
+


### PR DESCRIPTION
I wanted to pull out the responsibility of filtering messages which are blocked into a module so that : 
- we could close over a single observable of people I block (which is only instantiated once)
- people can over-ride it if they want

I tried a couple of implementations, and settled with making `message.sync.isBlocked`. 
(`feed.obs.filterBlocked` was my first choice, but this didn't work for `feed.obs.thread`, which needs a `pull.filter` and a sync check)

