### PR TITLE
rollup: don't filter out forked roots

### DIFF
--- a/feed/pull/rollup.js
+++ b/feed/pull/rollup.js
@@ -83,7 +83,7 @@ exports.create = function (api) {
       }),
 
       // FILTER
-      pull.filter(msg => msg && msg.value && !api.message.sync.root(msg)),
+      pull.filter(msg => msg && msg.value),
       pull.filter(rootFilter || (() => true)),
       pull.filter(msg => !api.message.sync.isBlocked(msg)),
 


### PR DESCRIPTION
This PR removes the explicit filter applied to rollup roots that requires them to be the top most level item.

The filter was causing forks to not be rendered in the main feed of patchwork. 

I am merging this immediately!

cc @mixmix 