### PR TITLE
split out backlink reply mapping into its own file (so it can be used on its own)

### DIFF
--- a/feed/pull/with-replies.js
+++ b/feed/pull/with-replies.js
@@ -1,0 +1,28 @@
+var pull = require('pull-stream')
+var nest = require('depnest')
+var extend = require('xtend')
+var resolve = require('mutant/resolve')
+var onceTrue = require('mutant/once-true')
+
+exports.needs = nest({
+  'backlinks.obs.for': 'first',
+  'message.sync.isBlocked': 'first',
+  'message.sync.root': 'first'
+})
+
+exports.gives = nest('feed.pull.withReplies', true)
+
+exports.create = function (api) {
+  return nest('feed.pull.withReplies', function () {
+    return pull.asyncMap((rootMessage, cb) => {
+      // use global backlinks cache
+      var backlinks = api.backlinks.obs.for(rootMessage.key)
+      onceTrue(backlinks.sync, () => {
+        var replies = resolve(backlinks).filter(msg => {
+          return api.message.sync.root(msg) === rootMessage.key && !api.message.sync.isBlocked(msg)
+        })
+        cb(null, extend(rootMessage, { replies }))
+      })
+    })
+  })
+}


### PR DESCRIPTION
`feed.pull.withReplies`

Pipe in root messages and out comes the messages extend with `{replies: [...]}`.

Same output as `feed.pull.rollup` except that it doesn't do the resolving of the roots (that's up to you, or whatever).

Merging now since I need this in patchwork ASAP and it won't (shouldn't) break anything.