### PR TITLE
Proposal for discussion: add some information for ssb-ooo when following another user

### DIFF
--- a/contact/async.js
+++ b/contact/async.js
@@ -1,10 +1,13 @@
 var nest = require('depnest')
 var ref = require('ssb-ref')
+var onceTrue = require('mutant/once-true')
+var About = require('ssb-ooo-about')
 
 exports.needs = nest({
   'contact.obs.following': 'first',
   'sbot.async.publish': 'first',
-  'sbot.async.friendsGet': 'first'
+  'sbot.async.friendsGet': 'first',
+  'sbot.obs.connection': 'first'
 })
 
 exports.gives = nest({
@@ -12,6 +15,7 @@ exports.gives = nest({
 })
 
 exports.create = function (api) {
+
   return nest({
     'contact.async': {follow, unfollow, followerOf, block, unblock}
   })
@@ -22,11 +26,34 @@ exports.create = function (api) {
 
   function follow (id, cb) {
     if (!ref.isFeed(id)) throw new Error('a feed id must be specified')
-    api.sbot.async.publish({
-      type: 'contact',
-      contact: id,
-      following: true
-    }, cb)
+
+    onceTrue(api.sbot.obs.connection, sbot => {
+      var aboutMessages = About(sbot, {});
+
+      aboutMessages.async.getLatestMsgIds( id, (err, aboutMessageIds) => {
+
+        if (err) {
+          cb(err, null)
+        } else {
+          
+          var followMsg = {
+            type: 'contact',
+            contact: id,
+            following: true
+          }
+
+          // If the user who is following the user is aware of their assigned
+          // name, description and image, we add those as a 'branch' field so
+          // a client can see parts of their profile by using ssb-ooo.
+          if (aboutMessageIds && aboutMessageIds.length > 0) {
+            followMsg['branch'] = aboutMessageIds;
+          }
+
+          api.sbot.async.publish(followMsg, cb)
+        }
+      })
+
+    })
   }
 
   function unfollow (id, cb) {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ssb-friends": "^2.2.3",
     "ssb-keys": "^7.0.9",
     "ssb-markdown": "^3.3.1",
+    "ssb-ooo-about": "^1.0.0",
     "ssb-ref": "^2.9.0",
     "ssb-sort": "^1.0.0",
     "xtend": "^4.0.1"


### PR DESCRIPTION
I thought it might be useful to add some information to the 'branch' field when following someone to tell other clients the name, description and display image of the person if they are out of the client's range.

I'm not sure if we need / want this, but I made the changes anyway as I knew it wouldn't take long.

Not sure where other clients would make use of this if we do want this. Perhaps as an sbot plugin that looks for unseen follow messages and calls 'get' on them?