### PR TITLE
add support for embedded audio/video and query strings on any kind of ssb ref

### DIFF
--- a/message/html/markdown.js
+++ b/message/html/markdown.js
@@ -49,9 +49,9 @@ exports.create = function (api) {
         toUrl: (id) => {
           if (ref.isBlob(id)) {
             var blob = ref.parseBlob(id)
-            var url = api.blob.sync.url(blob.id)
+            var url = api.blob.sync.url(blob.link)
             var query = {}
-            if (blob.key) query['unbox'] = blob.key + '.boxs'
+            if (blob.query && blob.query.unbox) query['unbox'] = blob.query.unbox
             if (typeLookup[blob.id]) query['contentType'] = typeLookup[blob.id]
             return url + '?' + querystring.stringify(query)
           }

--- a/message/html/markdown.js
+++ b/message/html/markdown.js
@@ -34,7 +34,7 @@ exports.create = function (api) {
         }
       })
     }
-
+    
     return h('Markdown', {
       hooks: [
         LoadingBlobHook(api.blob.obs.has)
@@ -52,7 +52,7 @@ exports.create = function (api) {
             var url = api.blob.sync.url(blob.link)
             var query = {}
             if (blob.query && blob.query.unbox) query['unbox'] = blob.query.unbox
-            if (typeLookup[blob.id]) query['contentType'] = typeLookup[blob.id]
+            if (typeLookup[blob.link]) query['contentType'] = typeLookup[blob.link]
             return url + '?' + querystring.stringify(query)
           }
           if (mentions[id]) {

--- a/message/html/markdown.js
+++ b/message/html/markdown.js
@@ -19,7 +19,6 @@ exports.create = function (api) {
 
   function markdown (content) {
     if (typeof content === 'string') { content = {text: content} }
-    // handle patchwork style mentions and custom emoji.
     var mentions = {}
     var typeLookup = {}
     var emojiMentions = {}
@@ -29,8 +28,13 @@ exports.create = function (api) {
           typeLookup[link.link] = link.type
         }
         if (link && link.name && link.link) {
-          if (link.emoji) emojiMentions[link.name] = link.link
-          else mentions['@' + link.name] = link.link
+          if (link.emoji) {
+            // handle custom emoji
+            emojiMentions[link.name] = link.link
+          } else {
+            // handle old-style patchwork v2 mentions (deprecated)
+            mentions['@' + link.name] = link.link
+          }
         }
       })
     }
@@ -47,18 +51,18 @@ exports.create = function (api) {
           return renderEmoji(emoji, url)
         },
         toUrl: (id) => {
-          if (ref.isBlob(id)) {
-            var blob = ref.parseBlob(id)
-            var url = api.blob.sync.url(blob.link)
+          var link = ref.parseLink(id)
+          if (link && ref.isBlob(link.link)) {
+            var url = api.blob.sync.url(link.link)
             var query = {}
-            if (blob.query && blob.query.unbox) query['unbox'] = blob.query.unbox
-            if (typeLookup[blob.link]) query['contentType'] = typeLookup[blob.link]
+            if (link.query && link.query.unbox) query['unbox'] = link.query.unbox
+            if (typeLookup[link.link]) query['contentType'] = typeLookup[link.link]
             return url + '?' + querystring.stringify(query)
-          }
-          if (mentions[id]) {
-            return mentions[id]
-          } else if (ref.isLink(id) || id.startsWith('#') || id.startsWith('?')) {
+          } else if (link || id.startsWith('#') || id.startsWith('?')) {
             return id
+          } else if (mentions[id]) {
+            // handle old-style patchwork v2 mentions (deprecated)
+            return mentions[id]
           }
           return false
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2695,20 +2695,18 @@
       }
     },
     "ssb-markdown": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-3.5.0.tgz",
-      "integrity": "sha512-wfD/JakZopuBMV4RiOgCyENjLyoB66tAdQWGZoLhFiZIxAyILoHs1FgUtGSiipNe2/vRWz3HlNxZsj2uAmdPlA==",
+      "version": "github:ssbc/ssb-markdown#eb631566d2e40f70cb3b1824df64a69294de8035",
       "requires": {
         "emoji-named-characters": "1.0.2",
-        "ssb-marked": "0.7.3",
+        "ssb-marked": "0.7.4",
         "ssb-msgs": "5.2.0",
         "ssb-ref": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba"
       }
     },
     "ssb-marked": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/ssb-marked/-/ssb-marked-0.7.3.tgz",
-      "integrity": "sha1-CKtsWtVADbApaV49E+39FcqIqW4="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/ssb-marked/-/ssb-marked-0.7.4.tgz",
+      "integrity": "sha1-MXFPFlSFMcmaA6JOIsfh67vOeHU="
     },
     "ssb-msgs": {
       "version": "5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2276,7 +2276,7 @@
         "pull-stream": "3.6.7",
         "ssb-about": "0.1.2",
         "ssb-keys": "7.0.14",
-        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
+        "ssb-ref": "2.11.0"
       },
       "dependencies": {
         "chloride": {
@@ -2564,7 +2564,7 @@
       "integrity": "sha512-/dvDJZdvukOHTjWDAUDdi5euG3fHIgW0z8xIWI+n+C3ugDCPad24josbRBMtgJ6e5piKOzstTlumIqfekvv8YQ==",
       "requires": {
         "flumeview-reduce": "1.3.13",
-        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
+        "ssb-ref": "2.11.0"
       },
       "dependencies": {
         "async-single": {
@@ -2667,7 +2667,7 @@
         "monotonic-timestamp": "0.0.9",
         "pull-stream": "3.6.0",
         "ssb-keys": "7.0.9",
-        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
+        "ssb-ref": "2.11.0"
       }
     },
     "ssb-friends": {
@@ -2681,7 +2681,7 @@
         "pull-cont": "0.1.1",
         "pull-flatmap": "0.0.1",
         "pull-stream": "3.6.0",
-        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
+        "ssb-ref": "2.11.0"
       }
     },
     "ssb-keys": {
@@ -2700,7 +2700,7 @@
         "emoji-named-characters": "1.0.2",
         "ssb-marked": "0.7.4",
         "ssb-msgs": "5.2.0",
-        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
+        "ssb-ref": "2.11.0"
       }
     },
     "ssb-marked": {
@@ -2713,11 +2713,13 @@
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
       "requires": {
-        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
+        "ssb-ref": "2.11.0"
       }
     },
     "ssb-ref": {
-      "version": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.0.tgz",
+      "integrity": "sha512-PbL/eBYydMEeyTDQDkMuHg2pvdmSnWidRI7Qu8kSlbGKzT43Ltv/bxoL3mGUTH378llMKhwNs0otxDLg/WHxzQ==",
       "requires": {
         "ip": "1.1.5",
         "is-valid-domain": "0.0.5"
@@ -2728,7 +2730,7 @@
       "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-1.0.0.tgz",
       "integrity": "sha1-jplW9QdS0rFYJHsG5Jw/SRwc0ns=",
       "requires": {
-        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
+        "ssb-ref": "2.11.0"
       }
     },
     "standard": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2695,7 +2695,9 @@
       }
     },
     "ssb-markdown": {
-      "version": "github:ssbc/ssb-markdown#d2549ace8713b2aecbc30fd133f648402caa33b6",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-3.6.0.tgz",
+      "integrity": "sha512-WaI/s6Zbq9EBAE9CD2OnPMn1U7Wce3HBK3EZN2qfnjIEkirL/oj8Wz92sBYyyV+tae1aJJRTV7/PFbT5YfNk+g==",
       "requires": {
         "emoji-named-characters": "1.0.2",
         "ssb-marked": "0.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2276,7 +2276,7 @@
         "pull-stream": "3.6.7",
         "ssb-about": "0.1.2",
         "ssb-keys": "7.0.14",
-        "ssb-ref": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba"
+        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
       },
       "dependencies": {
         "chloride": {
@@ -2564,7 +2564,7 @@
       "integrity": "sha512-/dvDJZdvukOHTjWDAUDdi5euG3fHIgW0z8xIWI+n+C3ugDCPad24josbRBMtgJ6e5piKOzstTlumIqfekvv8YQ==",
       "requires": {
         "flumeview-reduce": "1.3.13",
-        "ssb-ref": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba"
+        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
       },
       "dependencies": {
         "async-single": {
@@ -2667,7 +2667,7 @@
         "monotonic-timestamp": "0.0.9",
         "pull-stream": "3.6.0",
         "ssb-keys": "7.0.9",
-        "ssb-ref": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba"
+        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
       }
     },
     "ssb-friends": {
@@ -2681,7 +2681,7 @@
         "pull-cont": "0.1.1",
         "pull-flatmap": "0.0.1",
         "pull-stream": "3.6.0",
-        "ssb-ref": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba"
+        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
       }
     },
     "ssb-keys": {
@@ -2695,12 +2695,12 @@
       }
     },
     "ssb-markdown": {
-      "version": "github:ssbc/ssb-markdown#eb631566d2e40f70cb3b1824df64a69294de8035",
+      "version": "github:ssbc/ssb-markdown#d2549ace8713b2aecbc30fd133f648402caa33b6",
       "requires": {
         "emoji-named-characters": "1.0.2",
         "ssb-marked": "0.7.4",
         "ssb-msgs": "5.2.0",
-        "ssb-ref": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba"
+        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
       }
     },
     "ssb-marked": {
@@ -2713,11 +2713,11 @@
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
       "requires": {
-        "ssb-ref": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba"
+        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
       }
     },
     "ssb-ref": {
-      "version": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba",
+      "version": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b",
       "requires": {
         "ip": "1.1.5",
         "is-valid-domain": "0.0.5"
@@ -2728,7 +2728,7 @@
       "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-1.0.0.tgz",
       "integrity": "sha1-jplW9QdS0rFYJHsG5Jw/SRwc0ns=",
       "requires": {
-        "ssb-ref": "github:ssbc/ssb-ref#8289f9b02b5d05802a1cf34db9fb93737f30d3ba"
+        "ssb-ref": "github:ssbc/ssb-ref#d1e4bad853a3e373bb0a37852c0e7031af1d4d2b"
       }
     },
     "standard": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ssb-feed": "^2.3.0",
     "ssb-friends": "^2.2.3",
     "ssb-keys": "^7.0.9",
-    "ssb-markdown": "^3.3.1",
+    "ssb-markdown": "github:ssbc/ssb-markdown#embed-audio-video",
     "ssb-ref": "github:ssbc/ssb-ref#secret-blobs",
     "ssb-sort": "^1.0.0",
     "xtend": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ssb-feed": "^2.3.0",
     "ssb-friends": "^2.2.3",
     "ssb-keys": "^7.0.9",
-    "ssb-markdown": "github:ssbc/ssb-markdown#embed-audio-video",
+    "ssb-markdown": "^3.6.0",
     "ssb-ref": "^2.11.0",
     "ssb-sort": "^1.0.0",
     "xtend": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ssb-friends": "^2.2.3",
     "ssb-keys": "^7.0.9",
     "ssb-markdown": "github:ssbc/ssb-markdown#embed-audio-video",
-    "ssb-ref": "github:ssbc/ssb-ref#secret-blobs",
+    "ssb-ref": "^2.11.0",
     "ssb-sort": "^1.0.0",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
Pulls in changes from `ssb-markdown` and `ssb-ref`.

`[video:sometext](&someblob)` now renders as a video tag.

`[audio:sometext](&someblob)` now renders as a audio tag.

Can now link to a message, blob or feed with a query string [Some message](%someMsg?unbox=somekey).

Going to merge in 3, 2 ....

cc @mixmix 