### PR TITLE
feature: provides observables, sync and async methods, for sharing posts

### DIFF
--- a/message/async/share.js
+++ b/message/async/share.js
@@ -1,0 +1,31 @@
+const nest = require('depnest')
+const ref = require('ssb-ref')
+
+
+exports.gives = nest('message.async.share')
+
+exports.needs = nest({
+  'sbot.async.publish': 'first'
+})
+
+exports.create = function (api) {
+  return nest('message.async.share', function (kind, msg, captionOrUrl, cb) {
+    try {
+      let key = kind === 'internal' ? 'text' : 'url'
+      let share = {
+        type: 'share',
+        share: { link: msg.key, content: msg.value.content.type, [key]: captionOrUrl }
+      }
+      if (msg.value.content.recps) {
+        share.recps = msg.value.content.recps.map(function (e) {
+          return e && typeof e !== 'string' ? e.link : e
+        })
+        share.private = true
+      }
+      api.sbot.async.publish(share, cb)
+    } catch (n) {
+      cb({ error: "exception", msg: n.message }, null)
+    }
+  })
+}
+

--- a/message/obs/shares.js
+++ b/message/obs/shares.js
@@ -1,0 +1,88 @@
+let nest = require('depnest')
+let ref = require('ssb-ref')
+let MutantArray = require('mutant/array')
+let concat = require('mutant/concat')
+
+let { computed } = require('mutant')
+
+exports.needs = nest({
+  'message.sync.unbox': 'first',
+  'backlinks.obs.for': 'first',
+  'message.sync.isShare': 'first'
+})
+
+exports.gives = nest({
+  'sbot.hook.publish': true,
+  'message.obs.shares': true
+})
+
+exports.create = function (api) {
+  let activeShares = new Set()
+  let isShare = api.message.sync.isShare
+  return nest({
+    'sbot.hook.publish': (msg) => {
+      if (!(msg && msg.value && msg.value.content)) return
+      if (typeof msg.value.content === 'string') {
+        msg = api.message.sync.unbox(msg)
+        if (!msg) return
+      }
+
+      let c = msg.value.content
+      if (c.type !== 'share') return
+      if (!isShare('internal', c)) return
+
+      activeShares.forEach((shares) => {
+        if (shares.id === c.share.link) {
+          shares.push(msg)
+        }
+      })
+    },
+    'message.obs.shares': (id) => {
+      if (!ref.isLink(id)) throw new Error('an id must be specified')
+      let obs = get(id)
+      obs.id = id
+      let result = computed(obs, getShares, {
+        // allow manual append for simulated realtime
+        onListen: () => activeShares.add(obs),
+        onUnlisten: () => activeShares.delete(obs)
+      })
+      result.sync = obs.sync
+      return result
+    }
+  })
+
+  function get(id) {
+    let backlinks = api.backlinks.obs.for(id)
+    let merge = MutantArray()
+
+    let shares = computed([backlinks.sync, concat([backlinks, merge])], (sync, backlinks) => {
+      if (sync) {
+        return backlinks.reduce((result, msg) => {
+          let c = msg.value.content
+          if (isShare('internal', c) && c.share.link === id) {
+            let value = result[msg.value.author]
+            if (!value || value[0] < msg.value.timestamp) {
+              result[msg.value.author] = [msg.value.timestamp, c.share.text]
+            }
+          }
+          return result
+        }, {})
+      } else {
+        return {}
+      }
+    })
+
+    shares.push = merge.push
+    shares.sync = backlinks.sync
+    return shares
+  }
+}
+
+function getShares(shares) {
+  return Object.keys(shares).reduce((result, id) => {
+    if (shares[id].length >= 1) {
+      result.push(id)
+    }
+    return result
+  }, [])
+}

--- a/message/obs/webshares.js
+++ b/message/obs/webshares.js
@@ -1,0 +1,88 @@
+let nest = require('depnest')
+let ref = require('ssb-ref')
+let MutantArray = require('mutant/array')
+let concat = require('mutant/concat')
+
+let { computed } = require('mutant')
+
+exports.needs = nest({
+  'message.sync.unbox': 'first',
+  'backlinks.obs.for': 'first',
+  'message.sync.isShare': 'first'
+})
+
+exports.gives = nest({
+  'sbot.hook.publish': true,
+  'message.obs.webshares': true
+})
+
+exports.create = function (api) {
+  let activeShares = new Set()
+  let isShare = api.message.sync.isShare
+  return nest({
+    'sbot.hook.publish': (msg) => {
+      if (!(msg && msg.value && msg.value.content)) return
+      if (typeof msg.value.content === 'string') {
+        msg = api.message.sync.unbox(msg)
+        if (!msg) return
+      }
+
+      let c = msg.value.content
+
+      if (!isShare('external', c)) return
+
+      activeShares.forEach((shares) => {
+        if (shares.id === c.share.link) {
+          shares.push(msg)
+        }
+      })
+    },
+    'message.obs.webshares': (id) => {
+      if (!ref.isLink(id)) throw new Error('an id must be specified')
+      let obs = get(id)
+      obs.id = id
+      let result = computed(obs, getShares, {
+        // allow manual append for simulated realtime
+        onListen: () => activeShares.add(obs),
+        onUnlisten: () => activeShares.delete(obs)
+      })
+      result.sync = obs.sync
+      return result
+    }
+  })
+
+  function get(id) {
+    let backlinks = api.backlinks.obs.for(id)
+    let merge = MutantArray()
+
+    let shares = computed([backlinks.sync, concat([backlinks, merge])], (sync, backlinks) => {
+      if (sync) {
+        return backlinks.reduce((result, msg) => {
+          let c = msg.value.content
+          if (isShare('external', c) && c.share.link === id) {
+            let value = result[msg.value.author]
+            if (!value || value[0] < msg.value.timestamp) {
+              result[msg.value.author] = [msg.value.timestamp, c.share.url]
+            }
+          }
+          return result
+        }, {})
+      } else {
+        return {}
+      }
+    })
+
+    shares.push = merge.push
+    shares.sync = backlinks.sync
+    return shares
+  }
+}
+
+function getShares(shares) {
+  return Object.keys(shares).reduce((result, id) => {
+    if (shares[id].length >= 1) {
+      result.push(id)
+    }
+    return result
+  }, [])
+}

--- a/message/sync/is-share.js
+++ b/message/sync/is-share.js
@@ -1,0 +1,28 @@
+const nest = require('depnest')
+const ref = require('ssb-ref')
+
+exports.gives = nest('message.sync.isShare')
+
+exports.create = function (api) {
+  return nest('message.sync.isShare', function (kind, content) {
+    try {
+      let key = kind === 'internal' ? 'text' : 'url'
+
+      if (content.type !== 'share') return false
+
+      // breaking long if conditions into multiple lines dead ugly
+      // but it is better than scrolling horizontally.
+      if (!content.share
+        || !content.share.link
+        || !ref.isMsg(content.share.link)
+        || !content.share.hasOwnProperty(key)
+      ) {
+        return false
+      }
+
+      return true
+    } catch (n) {
+      return false
+    }
+  })
+}


### PR DESCRIPTION
## Ticktack sharing feature ported to patchcore
I've just externalized the sharing feature from Ticktack into their own patchcore modules. I've not ported the modal dialogs used and I've changed the API a bit so that except for the _observables_ for internal and external shares, all the other features use the same modules for both cases.

There are two types of sharing action: _internal_ and _external_. The first one is like a retweet or reblog and may contain a text caption. The other is for sharing the content to the larger Web by using a viewer URL. It doesn't contain a caption.

The following modules are provided:

* `message.sync.isShare`: can check for internal or external shares.
* `message.async.share`: will publish an internal or external share message.
* `message.obs.shares`: an observable for internal shares.
* `message.obs.webShares`: an observable for external shares.

