### PR TITLE
don't include replies in threads or rollups from people blocked by root message author

### DIFF
--- a/contact/obs.js
+++ b/contact/obs.js
@@ -10,7 +10,7 @@ exports.needs = nest({
 })
 
 exports.gives = nest({
-  'contact.obs': ['following', 'followers', 'blocking', 'blockers'],
+  'contact.obs': ['following', 'followers', 'blocking', 'blockers', 'raw'],
   'sbot.hook.publish': true
 })
 
@@ -32,7 +32,8 @@ exports.create = function (api) {
       following: (key) => matchingValueKeys(get(key, cache), true),
       followers: (key) => matchingValueKeys(get(key, reverseCache), true),
       blocking: (key) => matchingValueKeys(get(key, cache), false),
-      blockers: (key) => matchingValueKeys(get(key, reverseCache), false)
+      blockers: (key) => matchingValueKeys(get(key, reverseCache), false),
+      raw: (key) => get(key, cache)
     },
     'sbot.hook.publish': function (msg) {
       if (!isContact(msg)) return

--- a/feed/pull/with-replies.js
+++ b/feed/pull/with-replies.js
@@ -19,7 +19,7 @@ exports.create = function (api) {
       var backlinks = api.backlinks.obs.for(rootMessage.key)
       onceTrue(backlinks.sync, () => {
         var replies = resolve(backlinks).filter(msg => {
-          return api.message.sync.root(msg) === rootMessage.key && !api.message.sync.isBlocked(msg)
+          return api.message.sync.root(msg) === rootMessage.key && !api.message.sync.isBlocked(msg, rootMessage)
         })
         cb(null, extend(rootMessage, { replies }))
       })

--- a/message/sync/is-blocked.js
+++ b/message/sync/is-blocked.js
@@ -4,15 +4,24 @@ exports.gives = nest('message.sync.isBlocked')
 
 exports.needs = nest({
   'contact.obs.blocking': 'first',
+  'contact.obs.raw': 'first',
   'keys.sync.id': 'first'
 })
 
 exports.create = function (api) {
   var cache = null
 
-  return nest('message.sync.isBlocked', function isBlockedMessage (msg) {
+  return nest('message.sync.isBlocked', function isBlockedMessage (msg, rootMessage) {
     if (!cache) {
       cache = api.contact.obs.blocking(api.keys.sync.id())
+    }
+
+    if (rootMessage) {
+      // check if the author of the root message blocks the author of the message
+      var rawContact = api.contact.obs.raw(rootMessage.value.author)
+      if (rawContact()[msg.value.author] === false) {
+        return true
+      }
     }
 
     return cache().includes(msg.value.author)


### PR DESCRIPTION
This is something that came up a while back in [discussions about moderation](https://viewer.scuttlebot.io/%25kYS6xrmtePS0zFcZVNjd%2BTyDSahMwlnCYPXs3ksfsqM%3D.sha256) (`%kYS6xrmtePS0zFcZVNjd+TyDSahMwlnCYPXs3ksfsqM=.sha256`). 

The PR adds a check when rolling up replies and building threads to ensure that replies are only included if the author of the root message does not block the author of the reply.

It still includes replies to the blocked message, and the blocked message will still be directly viewable, but at least it removes it out of the main thread!

I'll probably be merging this soon, just creating this PR so that others know about this important patchcore change!

cc @mixmix 