### PR TITLE
Make filtered backstream observable abortable

### DIFF
--- a/backlinks/obs-cache.js
+++ b/backlinks/obs-cache.js
@@ -16,8 +16,8 @@ exports.create = function (api) {
 }
 
 /**
- * Creates a cache for backlinks observables by thread ID. The cache entry is a list
- * of messages built from a backlinks stream. The cache is evicted if there are no
+ * Creates a cache for backlinks observables by thread ID. The cache entry is an obserable
+ * list of messages built from a backlinks stream. The cache is evicted if there are no
  * listeners for the given backlinks observable for the configured amount of time,
  * or a default of 5 seconds
  */

--- a/backlinks/obs-cache.js
+++ b/backlinks/obs-cache.js
@@ -1,0 +1,100 @@
+var Value = require('mutant/value')
+var computed = require('mutant/computed')
+var Abortable = require('pull-abortable')
+var resolve = require('mutant/resolve')
+var pull = require('pull-stream')
+var onceIdle = require('mutant/once-idle')
+var nest = require('depnest')
+
+exports.gives = nest('backlinks.obs.cache', true)
+
+exports.create = function (api) {
+
+  return nest({
+    'backlinks.obs.cache': (cacheForMilliSeconds) => createCache(cacheForMilliSeconds)
+  })
+}
+
+/**
+ * Creates a cache for an observable that is a list of messages built from a
+ * backlinks stream. The cache is evicted if there are no listeners for the given
+ * backlinks observable for the configured amount of time, or a default of 5 seconds
+ */
+function createCache(cacheForMilliSeconds) {
+
+  var cache = {}
+
+  var newRemove = new Set()
+  var oldRemove = new Set()
+
+  function use (id) {
+    newRemove.delete(id)
+    oldRemove.delete(id)
+  }
+
+  function release (id) {
+    newRemove.add(id)
+  }
+
+  var timer = setInterval(() => {
+    oldRemove.forEach(id => {
+      if (cache[id]) {
+        cache[id].destroy()
+        delete cache[id]
+      }
+    })
+    oldRemove.clear()
+
+    // cycle
+    var hold = oldRemove
+    oldRemove = newRemove
+    newRemove = hold
+  }, cacheForMilliSeconds || 5e3)
+
+  if (timer.unref) timer.unref()
+
+  /**
+   * Takes a thread ID (for the cache ID) and a pull stream to populate the
+   * backlinks observable with. After the backlinks obserable is unsubscribed
+   * from it is cached for the configured amount of time before the pull stream
+   * is aborted unless there is a new incoming listener
+   */
+  function cachedBacklinks (id, backlinksPullStream) {
+
+    if (!cache[id]) {
+      var sync = Value(false)
+      var aborter = Abortable()
+      var collection = Value([])
+
+      // try not to saturate the thread
+      onceIdle(() => {
+        pull(
+          backlinksPullStream,
+          aborter,
+          pull.drain((msg) => {
+            if (msg.sync) {
+              sync.set(true)
+            } else {
+              var value = resolve(collection)
+              value.push(msg)
+              collection.set(value)
+            }
+          })
+        )
+      })
+
+      cache[id] = computed([collection], x => x, {
+        onListen: () => use(id),
+        onUnlisten: () => release(id)
+      })
+
+      cache[id].destroy = aborter.abort
+      cache[id].sync = sync
+    }
+    return cache[id]
+  }
+
+  return {
+    cachedBacklinks: cachedBacklinks
+  }
+}

--- a/backlinks/obs-cache.js
+++ b/backlinks/obs-cache.js
@@ -16,9 +16,10 @@ exports.create = function (api) {
 }
 
 /**
- * Creates a cache for an observable that is a list of messages built from a
- * backlinks stream. The cache is evicted if there are no listeners for the given
- * backlinks observable for the configured amount of time, or a default of 5 seconds
+ * Creates a cache for backlinks observables by thread ID. The cache entry is a list
+ * of messages built from a backlinks stream. The cache is evicted if there are no
+ * listeners for the given backlinks observable for the configured amount of time,
+ * or a default of 5 seconds
  */
 function createCache(cacheForMilliSeconds) {
 

--- a/backlinks/obs-filter.js
+++ b/backlinks/obs-filter.js
@@ -19,7 +19,7 @@ exports.gives = nest('backlinks.obs.filter', true)
  *
  * An optional backlinks cache (which should be constructed from backlinks.obs.cache can be
  * supplied with opts.cache. A caller constructed cache is required because different
- * pull stream filters might be used for different threads.
+ * pull stream filters might be used for the same thread ID.
  *
  * A 'sync' observable property is also added to the returned observable
  * which is 'true' when all previously seen messages are caught up with.

--- a/backlinks/obs-filter.js
+++ b/backlinks/obs-filter.js
@@ -1,6 +1,5 @@
 var nest = require('depnest')
 var pull = require('pull-stream')
-var BacklinksCache = require('./obs-cache')
 
 exports.needs = nest({
   'sbot.pull.backlinks': 'first',

--- a/backlinks/obs-filter.js
+++ b/backlinks/obs-filter.js
@@ -66,9 +66,11 @@ exports.create = function (api) {
     'backlinks.obs.filter': (id, opts) => {
 
       // We cannot use a global cache as a consumer might use multiple
-      // observables with different filters. If the caller does not supply
-      // their own cache (constructed from obs-cache) we just create a new one
-      // per observable (effectively no cache, but with the correct cleanup behaviour.)
+      // observables for the same thread ID with different filters. If the caller
+      // does not supply their own cache (constructed from obs-cache) we just
+      // create a new one per observable (effectively no cache, but with the correct
+      // cleanup behaviour when there are no listeners to the observable from the live
+      // pullstream .)
       if (!opts || !opts.cache) {
         cache = api.backlinks.obs.cache();
       }

--- a/backlinks/obs-filter.js
+++ b/backlinks/obs-filter.js
@@ -22,15 +22,14 @@ exports.gives = nest('backlinks.obs.filter', true)
  * and passing it to the filter function does not result in it returning
  * 'true' the message is not added to the observable list.
  *
- * An optional backlinks cache (which should be constructed from backlinks.obs.cache can be
+ * An optional backlinks cache (which should be constructed from backlinks.obs.cache) can be
  * supplied with opts.cache. A caller constructed cache is required because different
- * pull stream filters might be used for the same thread ID.
+ * pull stream filters might be used for the same thread ID. If no cache is supplied,
+ * the backlinks observables will not be cached.
  *
  * A 'sync' observable property is also added to the returned observable
  * which is 'true' when all previously seen messages are caught up with.
  *
- * Note: Unlike backlinks.obs.for this does not cache the observable for
- * callers that supply the same arguments.
  */
 exports.create = function (api) {
 

--- a/backlinks/obs-filter.js
+++ b/backlinks/obs-filter.js
@@ -17,6 +17,10 @@ exports.gives = nest('backlinks.obs.filter', true)
  * and passing it to the filter function does not result in it returning
  * 'true' the message is not added to the observable list.
  *
+ * An optional backlinks cache (which should be constructed from backlinks.obs.cache can be
+ * supplied with opts.cache. A caller constructed cache is required because different
+ * pull stream filters might be used for different threads.
+ *
  * A 'sync' observable property is also added to the returned observable
  * which is 'true' when all previously seen messages are caught up with.
  *
@@ -25,9 +29,7 @@ exports.gives = nest('backlinks.obs.filter', true)
  */
 exports.create = function (api) {
 
-  var backlinksCache = api.backlinks.obs.cache();
-
-  function pullFilterReduceObs (id, opts) {
+  function pullFilterReduceObs (id, opts, backlinksCache) {
     if (!id || typeof (id) !== 'string') {
       throw new Error('id must be a string.')
     }
@@ -61,6 +63,17 @@ exports.create = function (api) {
   }
 
   return nest({
-    'backlinks.obs.filter': (id, opts) => pullFilterReduceObs(id, opts)
+    'backlinks.obs.filter': (id, opts) => {
+
+      // We cannot use a global cache as a consumer might use multiple
+      // observables with different filters. If the caller does not supply
+      // their own cache (constructed from obs-cache) we just create a new one
+      // per observable (effectively no cache, but with the correct cleanup behaviour.)
+      if (!opts || !opts.cache) {
+        cache = api.backlinks.obs.cache();
+      }
+
+      return pullFilterReduceObs(id, opts, cache)
+    }
   })
 }

--- a/backlinks/obs-filter.js
+++ b/backlinks/obs-filter.js
@@ -29,7 +29,7 @@ exports.gives = nest('backlinks.obs.filter', true)
  */
 exports.create = function (api) {
 
-  function pullFilterReduceObs (id, opts, backlinksCache) {
+  function pullFilterReduceObs (id, filterFunction, backlinksCache) {
     if (!id || typeof (id) !== 'string') {
       throw new Error('id must be a string.')
     }
@@ -46,10 +46,6 @@ exports.create = function (api) {
       live: true
     })
 
-    // If a filter function is supplied in the options, we use it to filter
-    // the links stream, otherwise we use all the messages from the stream
-    var filterFunction = opts && opts.filter ? opts.filter : () => true
-
     var filteredBacklinks = pull(
       msgBacklinks,
       // We need to allow 'msg.sync' even if the supplied filter function does not
@@ -65,6 +61,10 @@ exports.create = function (api) {
   return nest({
     'backlinks.obs.filter': (id, opts) => {
 
+      // If a filter function is supplied in the options, we use it to filter
+      // the links stream, otherwise we use all the messages from the stream
+      var filterFunction = opts && opts.filter ? opts.filter : () => true
+
       // We cannot use a global cache as a consumer might use multiple
       // observables for the same thread ID with different filters. If the caller
       // does not supply their own cache (constructed from obs-cache) we just
@@ -75,7 +75,7 @@ exports.create = function (api) {
         cache = api.backlinks.obs.cache();
       }
 
-      return pullFilterReduceObs(id, opts, cache)
+      return pullFilterReduceObs(id, filterFunction, cache)
     }
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -32,8 +32,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -70,7 +70,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-union": {
@@ -79,7 +79,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -109,9 +109,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
       "requires": {
-        "chalk": "^1.1.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
       },
       "dependencies": {
         "esutils": {
@@ -126,25 +126,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
       "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "babel-generator": "^6.25.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.25.0",
-        "babel-traverse": "^6.25.0",
-        "babel-types": "^6.25.0",
-        "babylon": "^6.17.2",
-        "convert-source-map": "^1.1.0",
-        "debug": "^2.1.1",
-        "json5": "^0.5.0",
-        "lodash": "^4.2.0",
-        "minimatch": "^3.0.2",
-        "path-is-absolute": "^1.0.0",
-        "private": "^0.1.6",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.0"
+        "babel-code-frame": "6.22.0",
+        "babel-generator": "6.25.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.8",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.7",
+        "slash": "1.0.0",
+        "source-map": "0.5.6"
       },
       "dependencies": {
         "minimatch": {
@@ -152,7 +152,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "source-map": {
@@ -167,14 +167,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.25.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.2.0",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -189,10 +189,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -200,8 +200,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -209,8 +209,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
       }
     },
     "babel-helpers": {
@@ -218,8 +218,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
       }
     },
     "babel-messages": {
@@ -227,7 +227,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -235,7 +235,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -243,7 +243,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -251,11 +251,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1",
-        "lodash": "^4.2.0"
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -263,8 +263,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -272,7 +272,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -280,12 +280,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -293,8 +293,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -302,7 +302,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -310,7 +310,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-preset-es2040": {
@@ -318,15 +318,15 @@
       "resolved": "https://registry.npmjs.org/babel-preset-es2040/-/babel-preset-es2040-1.1.1.tgz",
       "integrity": "sha1-QIzDNyRwggXHgGZ7kw+njfW8j5Q=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.8.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.9.0",
-        "babel-plugin-transform-es2015-parameters": "^6.9.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.8.0",
-        "babel-plugin-transform-es2015-spread": "^6.8.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.8.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0"
       }
     },
     "babel-register": {
@@ -334,13 +334,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
       "requires": {
-        "babel-core": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "core-js": "^2.4.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.2"
+        "babel-core": "6.25.0",
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.15"
       }
     },
     "babel-runtime": {
@@ -348,8 +348,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.10.0"
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
       }
     },
     "babel-template": {
@@ -357,11 +357,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.25.0",
-        "babel-types": "^6.25.0",
-        "babylon": "^6.17.2",
-        "lodash": "^4.2.0"
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3",
+        "lodash": "4.17.4"
       }
     },
     "babel-traverse": {
@@ -369,15 +369,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.25.0",
-        "babylon": "^6.17.2",
-        "debug": "^2.2.0",
-        "globals": "^9.0.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
       }
     },
     "babel-types": {
@@ -385,10 +385,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
-        "to-fast-properties": "^1.0.1"
+        "babel-runtime": "6.23.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
       },
       "dependencies": {
         "esutils": {
@@ -413,7 +413,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -427,7 +427,7 @@
       "resolved": "https://registry.npmjs.org/bulk-require/-/bulk-require-1.0.0.tgz",
       "integrity": "sha1-fITp3SWgN3wNDeqpIHIwcUG0PKg=",
       "requires": {
-        "glob": "~3.2.7"
+        "glob": "3.2.11"
       }
     },
     "bulkify": {
@@ -435,10 +435,10 @@
       "resolved": "https://registry.npmjs.org/bulkify/-/bulkify-1.4.2.tgz",
       "integrity": "sha1-eEjw86uX8SpBuSO/kOU+Ceqvukw=",
       "requires": {
-        "bulk-require": "^1.0.0",
-        "concat-stream": "^1.4.5",
-        "static-module": "^1.1.2",
-        "through2": "~0.4.1"
+        "bulk-require": "1.0.0",
+        "concat-stream": "1.6.0",
+        "static-module": "1.3.2",
+        "through2": "0.4.2"
       }
     },
     "caller-path": {
@@ -447,7 +447,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -461,11 +461,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "chloride": {
@@ -473,11 +473,11 @@
       "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.7.tgz",
       "integrity": "sha1-DmqdEYlKvkpEkR05iNoZLiIIt4Y=",
       "requires": {
-        "is-electron": "^2.0.0",
-        "sodium-browserify": "^1.0.3",
-        "sodium-browserify-tweetnacl": "^0.2.0",
-        "sodium-chloride": "^1.1.0",
-        "sodium-native": "^1.10.0"
+        "is-electron": "2.0.0",
+        "sodium-browserify": "1.2.1",
+        "sodium-browserify-tweetnacl": "0.2.3",
+        "sodium-chloride": "1.1.0",
+        "sodium-native": "1.10.1"
       }
     },
     "chloride-test": {
@@ -485,7 +485,7 @@
       "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
       "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
       "requires": {
-        "json-buffer": "^2.0.11"
+        "json-buffer": "2.0.11"
       }
     },
     "circular-json": {
@@ -500,7 +500,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-width": {
@@ -536,9 +536,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.11",
+        "typedarray": "0.0.6"
       }
     },
     "cont": {
@@ -546,9 +546,9 @@
       "resolved": "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz",
       "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
       "requires": {
-        "continuable": "~1.2.0",
-        "continuable-para": "~1.2.0",
-        "continuable-series": "~1.2.0"
+        "continuable": "1.2.0",
+        "continuable-para": "1.2.0",
+        "continuable-series": "1.2.0"
       }
     },
     "continuable": {
@@ -561,7 +561,7 @@
       "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
       "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
       "requires": {
-        "continuable": "~1.1.6"
+        "continuable": "1.1.8"
       },
       "dependencies": {
         "continuable": {
@@ -576,7 +576,7 @@
       "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
       "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
       "requires": {
-        "continuable": "~1.1.6"
+        "continuable": "1.1.8"
       },
       "dependencies": {
         "continuable": {
@@ -591,8 +591,8 @@
       "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
       "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
       "requires": {
-        "continuable-hash": "~0.1.4",
-        "continuable-list": "~0.1.5"
+        "continuable-hash": "0.1.4",
+        "continuable-list": "0.1.6"
       }
     },
     "continuable-series": {
@@ -621,7 +621,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.23"
       }
     },
     "debug": {
@@ -660,12 +660,12 @@
       "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
       "dev": true,
       "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^3.0.9",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
+        "find-root": "1.0.0",
+        "glob": "7.1.2",
+        "ignore": "3.3.3",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.6",
+        "uniq": "1.0.1"
       },
       "dependencies": {
         "glob": {
@@ -674,12 +674,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -688,7 +688,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -699,21 +699,20 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
       }
     },
     "depject": {
       "version": "github:dominictarr/depject#7af441ad1127d82df8cbab324cea7b71a178b2a2",
-      "from": "github:dominictarr/depject#reduce-with-context",
       "dev": true,
       "requires": {
-        "libnested": "^1.1.0"
+        "libnested": "1.2.1"
       }
     },
     "depnest": {
@@ -721,8 +720,8 @@
       "resolved": "https://registry.npmjs.org/depnest/-/depnest-1.3.0.tgz",
       "integrity": "sha1-FL2KNh30RdLTT37LNi1sdFcoiVk=",
       "requires": {
-        "es2040": "^1.2.3",
-        "libnested": "^1.2.1"
+        "es2040": "1.2.5",
+        "libnested": "1.2.1"
       }
     },
     "detect-indent": {
@@ -730,7 +729,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "doctrine": {
@@ -739,8 +738,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "isarray": "^1.0.0"
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
       },
       "dependencies": {
         "esutils": {
@@ -756,7 +755,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -769,10 +768,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -787,7 +786,7 @@
       "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
       "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
       "requires": {
-        "tweetnacl": "0.x.x"
+        "tweetnacl": "0.14.5"
       }
     },
     "electro": {
@@ -796,7 +795,7 @@
       "integrity": "sha1-shj320WTvEloFHsAaqR858+/tzo=",
       "dev": true,
       "requires": {
-        "minimist": "~1.2.0"
+        "minimist": "1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -817,9 +816,9 @@
       "resolved": "https://registry.npmjs.org/es2040/-/es2040-1.2.5.tgz",
       "integrity": "sha1-pTXdfURyujRs3oDl1C/N+TmqT3c=",
       "requires": {
-        "babel-core": "^6.9.1",
-        "babel-preset-es2040": "^1.1.0",
-        "through2": "^2.0.1"
+        "babel-core": "6.25.0",
+        "babel-preset-es2040": "1.1.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "through2": {
@@ -827,8 +826,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.2.11",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -839,8 +838,8 @@
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2",
-        "es6-symbol": "~3.1"
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
@@ -849,9 +848,9 @@
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-symbol": "^3.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -860,12 +859,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-set": {
@@ -874,11 +873,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -887,8 +886,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
       }
     },
     "es6-weak-map": {
@@ -897,10 +896,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -913,10 +912,10 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
       "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
       "requires": {
-        "esprima": "~1.1.1",
-        "estraverse": "~1.5.0",
-        "esutils": "~1.0.0",
-        "source-map": "~0.1.33"
+        "esprima": "1.1.1",
+        "estraverse": "1.5.1",
+        "esutils": "1.0.0",
+        "source-map": "0.1.43"
       }
     },
     "escope": {
@@ -925,10 +924,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.1.0",
+        "estraverse": "4.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -945,40 +944,40 @@
       "integrity": "sha1-yaEOi/bp1lZRIEd4xQM0Hx6sPOc=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.16.0",
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.4.6",
-        "debug": "^2.1.1",
-        "doctrine": "^1.2.2",
-        "escope": "^3.6.0",
-        "espree": "^3.3.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "glob": "^7.0.3",
-        "globals": "^9.2.0",
-        "ignore": "^3.2.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.7.5",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "~1.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "1.5.0",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.8.4",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
       },
       "dependencies": {
         "estraverse": {
@@ -999,12 +998,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -1013,7 +1012,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "strip-json-comments": {
@@ -1048,8 +1047,8 @@
       "integrity": "sha1-Gvlq6lRYVoJRV9l8G1DVqPtkpac=",
       "dev": true,
       "requires": {
-        "doctrine": "^1.2.2",
-        "jsx-ast-utils": "^1.3.3"
+        "doctrine": "1.5.0",
+        "jsx-ast-utils": "1.4.1"
       }
     },
     "eslint-plugin-standard": {
@@ -1064,8 +1063,8 @@
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.1",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.0.3",
+        "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -1087,8 +1086,8 @@
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
       "requires": {
-        "estraverse": "~4.1.0",
-        "object-assign": "^4.0.1"
+        "estraverse": "4.1.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "estraverse": {
@@ -1115,8 +1114,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
       }
     },
     "exit-hook": {
@@ -1135,10 +1134,10 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
       "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
       "requires": {
-        "acorn": "^1.0.3",
-        "foreach": "^2.0.5",
+        "acorn": "1.2.2",
+        "foreach": "2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "^1.0.6"
+        "object-keys": "1.0.11"
       },
       "dependencies": {
         "isarray": {
@@ -1160,8 +1159,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-entry-cache": {
@@ -1170,8 +1169,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
       }
     },
     "find-root": {
@@ -1185,7 +1184,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.0.0.tgz",
       "integrity": "sha512-ji/WMv2jdsE+LaznpkIF9Haax0sdpTBozrz/Dtg4qSRMfbs8oVg4ypJunIRYPiMLvH/ed6OflXbnbTIKJhtgeg==",
       "requires": {
-        "is-buffer": "~1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "flat-cache": {
@@ -1194,10 +1193,10 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "flumecodec": {
@@ -1205,7 +1204,7 @@
       "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
       "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
       "requires": {
-        "level-codec": "^6.2.0"
+        "level-codec": "6.2.0"
       }
     },
     "flumeview-reduce": {
@@ -1213,13 +1212,13 @@
       "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.3.tgz",
       "integrity": "sha512-fAu2R81ycHdXvt4sZV+CT3cQeMFxrizXAGjsUONctOZHM0SHpNvUEkLZlN5n8C1/6D8nD1T9QnMQIscTtRgv+g==",
       "requires": {
-        "async-single": "^1.0.0",
-        "atomic-file": "^0.3.0",
-        "deep-equal": "^1.0.1",
+        "async-single": "1.0.1",
+        "atomic-file": "0.3.0",
+        "deep-equal": "1.0.1",
         "flumecodec": "0.0.0",
         "obv": "0.0.0",
-        "pull-notify": "^0.1.1",
-        "pull-stream": "^3.5.0"
+        "pull-notify": "0.1.1",
+        "pull-stream": "3.6.0"
       },
       "dependencies": {
         "obv": {
@@ -1255,7 +1254,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-stdin": {
@@ -1269,8 +1268,8 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "requires": {
-        "inherits": "2",
-        "minimatch": "0.3"
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
       }
     },
     "globals": {
@@ -1284,12 +1283,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "glob": {
@@ -1298,12 +1297,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -1312,7 +1311,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -1328,7 +1327,7 @@
       "resolved": "https://registry.npmjs.org/graphreduce/-/graphreduce-3.0.4.tgz",
       "integrity": "sha1-v0QtCoeOg5AeXvPmUtI/+1uDHtc=",
       "requires": {
-        "statistics": "^3.3.0"
+        "statistics": "3.3.0"
       }
     },
     "has": {
@@ -1336,7 +1335,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.0"
       }
     },
     "has-ansi": {
@@ -1344,7 +1343,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "hashlru": {
@@ -1357,8 +1356,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "html-escape": {
@@ -1394,8 +1393,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1414,19 +1413,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
       }
     },
     "insert-css": {
@@ -1446,7 +1445,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "ip": {
@@ -1469,7 +1468,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -1478,7 +1477,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-my-ip-valid": {
@@ -1492,10 +1491,10 @@
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-path-cwd": {
@@ -1510,7 +1509,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.0"
       }
     },
     "is-path-inside": {
@@ -1519,7 +1518,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-property": {
@@ -1533,7 +1532,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "^1.0.1"
+        "tryit": "1.0.3"
       }
     },
     "is-valid-domain": {
@@ -1557,8 +1556,8 @@
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^3.1.1"
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
       },
       "dependencies": {
         "esprima": {
@@ -1585,7 +1584,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json5": {
@@ -1621,8 +1620,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "libnested": {
@@ -1658,7 +1657,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.1"
       }
     },
     "lru-cache": {
@@ -1671,8 +1670,8 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
       "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
       "requires": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
       }
     },
     "minimist": {
@@ -1708,13 +1707,13 @@
       "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.10.0.tgz",
       "integrity": "sha1-0pig0AKOClhvkLufyURoTUI5D4g=",
       "requires": {
-        "pull-cat": "~1.1.5",
-        "pull-stream": "^3.4.3",
-        "pull-ws": "^3.2.7",
-        "secret-handshake": "^1.1.5",
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.0",
+        "pull-ws": "3.3.0",
+        "secret-handshake": "1.1.12",
         "separator-escape": "0.0.0",
         "socks": "1.1.9",
-        "stream-to-pull-stream": "^1.7.2"
+        "stream-to-pull-stream": "1.7.2"
       }
     },
     "mutant": {
@@ -1723,7 +1722,7 @@
       "integrity": "sha1-Ez3McBQG5vHQJZHiOjVc+ufIy1M=",
       "requires": {
         "browser-split": "0.0.1",
-        "xtend": "^4.0.1"
+        "xtend": "4.0.1"
       }
     },
     "mutant-pull-reduce": {
@@ -1731,9 +1730,9 @@
       "resolved": "https://registry.npmjs.org/mutant-pull-reduce/-/mutant-pull-reduce-1.1.0.tgz",
       "integrity": "sha1-lvdwJ7QABhNkrL8mM74ugtVEDmo=",
       "requires": {
-        "mutant": "^3.14.1",
+        "mutant": "3.21.2",
         "pull-pause": "0.0.0",
-        "pull-stream": "^3.5.0"
+        "pull-stream": "3.6.0"
       }
     },
     "mute-stream": {
@@ -1747,11 +1746,11 @@
       "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.3.3.tgz",
       "integrity": "sha1-aK2UDvf2Ad+dqe8iEbChc9Uob50=",
       "requires": {
-        "explain-error": "^1.0.1",
-        "packet-stream": "~2.0.0",
-        "packet-stream-codec": "^1.1.1",
-        "pull-goodbye": "~0.0.1",
-        "pull-stream": "^3.2.3"
+        "explain-error": "1.0.4",
+        "packet-stream": "2.0.2",
+        "packet-stream-codec": "1.1.2",
+        "pull-goodbye": "0.0.2",
+        "pull-stream": "3.6.0"
       }
     },
     "nan": {
@@ -1777,7 +1776,7 @@
       "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.2.tgz",
       "integrity": "sha1-7VH6e/fpGpxjI5TxBUe2o5Xovq0=",
       "requires": {
-        "ip": "~0.3.2"
+        "ip": "0.3.3"
       },
       "dependencies": {
         "ip": {
@@ -1819,7 +1818,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -1834,12 +1833,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "options": {
@@ -1867,8 +1866,8 @@
       "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
       "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
       "requires": {
-        "pull-reader": "^1.2.4",
-        "pull-through": "^1.0.17"
+        "pull-reader": "1.2.9",
+        "pull-through": "1.0.18"
       }
     },
     "path-is-absolute": {
@@ -1911,7 +1910,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-config": {
@@ -1920,9 +1919,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
+        "debug-log": "1.0.1",
+        "find-root": "1.0.0",
+        "xtend": "4.0.1"
       }
     },
     "pluralize": {
@@ -1947,7 +1946,7 @@
       "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.2.1.tgz",
       "integrity": "sha1-HfBhr8pbMDnH/qrdDa8PVvB+PsA=",
       "requires": {
-        "chloride": "^2.2.1"
+        "chloride": "2.2.7"
       }
     },
     "process-nextick-args": {
@@ -1971,12 +1970,12 @@
       "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
       "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
       "requires": {
-        "chloride": "^2.2.7",
-        "increment-buffer": "~1.0.0",
-        "pull-reader": "^1.2.5",
-        "pull-stream": "^3.2.3",
-        "pull-through": "^1.0.18",
-        "split-buffer": "~1.0.0"
+        "chloride": "2.2.7",
+        "increment-buffer": "1.0.1",
+        "pull-reader": "1.2.9",
+        "pull-stream": "3.6.0",
+        "pull-through": "1.0.18",
+        "split-buffer": "1.0.0"
       }
     },
     "pull-cat": {
@@ -2004,7 +2003,7 @@
       "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
       "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
       "requires": {
-        "pull-stream": "~3.5.0"
+        "pull-stream": "3.5.0"
       },
       "dependencies": {
         "pull-stream": {
@@ -2019,10 +2018,10 @@
       "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
       "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
       "requires": {
-        "pull-cat": "^1.1.9",
-        "pull-pair": "~1.1.0",
-        "pull-pushable": "^2.0.0",
-        "pull-reader": "^1.2.3"
+        "pull-cat": "1.1.11",
+        "pull-pair": "1.1.0",
+        "pull-pushable": "2.1.1",
+        "pull-reader": "1.2.9"
       }
     },
     "pull-hash": {
@@ -2035,7 +2034,7 @@
       "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
       "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
       "requires": {
-        "pull-pushable": "^2.0.0"
+        "pull-pushable": "2.1.1"
       }
     },
     "pull-pair": {
@@ -2063,7 +2062,7 @@
       "resolved": "https://registry.npmjs.org/pull-reconnect/-/pull-reconnect-0.0.3.tgz",
       "integrity": "sha1-U9zpzS8rmyEOiIleGfL/xnYh3J4=",
       "requires": {
-        "pull-defer": "^0.2.2"
+        "pull-defer": "0.2.2"
       }
     },
     "pull-stream": {
@@ -2076,7 +2075,7 @@
       "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
       "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
       "requires": {
-        "looper": "~3.0.0"
+        "looper": "3.0.0"
       }
     },
     "pull-ws": {
@@ -2084,9 +2083,9 @@
       "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.0.tgz",
       "integrity": "sha1-4cQ+9AMyFn3YEg71nt9+iSvqSq4=",
       "requires": {
-        "relative-url": "^1.0.2",
-        "safe-buffer": "^5.1.1",
-        "ws": "^1.1.0"
+        "relative-url": "1.0.2",
+        "safe-buffer": "5.1.1",
+        "ws": "1.1.5"
       },
       "dependencies": {
         "safe-buffer": {
@@ -2102,7 +2101,7 @@
       "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
       "requires": {
         "minimist": "0.0.8",
-        "through2": "~0.4.1"
+        "through2": "0.4.2"
       }
     },
     "rc": {
@@ -2110,10 +2109,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "requires": {
-        "deep-extend": "~0.4.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -2128,13 +2127,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
       "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.0.1",
-        "string_decoder": "~1.0.0",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.0.1",
+        "string_decoder": "1.0.2",
+        "util-deprecate": "1.0.2"
       }
     },
     "readline2": {
@@ -2143,8 +2142,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -2154,7 +2153,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.3.3"
       }
     },
     "regenerator-runtime": {
@@ -2172,7 +2171,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "require-uncached": {
@@ -2181,8 +2180,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -2191,7 +2190,7 @@
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-from": {
@@ -2206,8 +2205,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "rimraf": {
@@ -2216,7 +2215,7 @@
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       },
       "dependencies": {
         "glob": {
@@ -2225,12 +2224,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -2239,7 +2238,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -2250,7 +2249,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0"
+        "once": "1.4.0"
       }
     },
     "run-parallel": {
@@ -2275,14 +2274,14 @@
       "resolved": "https://registry.npmjs.org/scuttle-blog/-/scuttle-blog-1.0.0.tgz",
       "integrity": "sha512-EjrPE4vPzJq4JQDw0c7vOgQH1nDC2UgmoMyJo5/aurNF4DABh+BCp+Univq1jHAVZpyYloYcwofl1UXh1TkBYg==",
       "requires": {
-        "is-my-json-valid": "^2.17.1",
-        "libnested": "^1.2.1",
-        "lodash": "^4.17.4",
-        "mutant": "^3.22.1",
-        "pull-stream": "^3.6.1",
-        "ssb-about": "^0.1.2",
-        "ssb-keys": "^7.0.13",
-        "ssb-ref": "^2.9.1"
+        "is-my-json-valid": "2.17.2",
+        "libnested": "1.2.1",
+        "lodash": "4.17.4",
+        "mutant": "3.22.1",
+        "pull-stream": "3.6.7",
+        "ssb-about": "0.1.2",
+        "ssb-keys": "7.0.14",
+        "ssb-ref": "2.11.0"
       },
       "dependencies": {
         "chloride": {
@@ -2290,11 +2289,11 @@
           "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.9.tgz",
           "integrity": "sha512-5nXmworu/Mwelj96V1ho+vKSnb68oyZieoMeit5iUPQquIBypThYH2mpXcXnztN9ahV3xvOXvLpn3gGpIxHjrg==",
           "requires": {
-            "is-electron": "^2.0.0",
-            "sodium-browserify": "^1.2.4",
-            "sodium-browserify-tweetnacl": "^0.2.2",
-            "sodium-chloride": "^1.1.0",
-            "sodium-native": "^2.0.0"
+            "is-electron": "2.0.0",
+            "sodium-browserify": "1.2.4",
+            "sodium-browserify-tweetnacl": "0.2.3",
+            "sodium-chloride": "1.1.0",
+            "sodium-native": "2.1.5"
           }
         },
         "ini": {
@@ -2308,11 +2307,11 @@
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
           "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
           "requires": {
-            "generate-function": "^2.0.0",
-            "generate-object-property": "^1.1.0",
-            "is-my-ip-valid": "^1.0.0",
-            "jsonpointer": "^4.0.0",
-            "xtend": "^4.0.0"
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "is-my-ip-valid": "1.0.0",
+            "jsonpointer": "4.0.1",
+            "xtend": "4.0.1"
           }
         },
         "libsodium": {
@@ -2334,7 +2333,7 @@
           "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
           "requires": {
             "browser-split": "0.0.1",
-            "xtend": "^4.0.1"
+            "xtend": "4.0.1"
           }
         },
         "pull-stream": {
@@ -2347,10 +2346,10 @@
           "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.4.tgz",
           "integrity": "sha512-IYcxKje/uf/c3a7VhZYJLlUxWMcktfbD4AjqHjUD1/VWKjj0Oq5wNbX8wjJOWVO9UhUMqJQiOn2xFbzKWBmy5w==",
           "requires": {
-            "libsodium-wrappers": "^0.7.3",
+            "libsodium-wrappers": "0.7.3",
             "sha.js": "2.4.5",
-            "sodium-browserify-tweetnacl": "^0.2.3",
-            "tweetnacl": "^0.14.1"
+            "sodium-browserify-tweetnacl": "0.2.3",
+            "tweetnacl": "0.14.5"
           }
         },
         "sodium-native": {
@@ -2359,9 +2358,9 @@
           "integrity": "sha512-We1ANTbM/iWeHbIpCFo5Nd95pwsLHRjH6h6hg2tlKjKDFUBFsVDk+ewlNjK2CRejpQtimD0GOexT0N/TO5PG2Q==",
           "optional": true,
           "requires": {
-            "ini": "^1.3.5",
-            "nan": "^2.4.0",
-            "node-gyp-build": "^3.0.0"
+            "ini": "1.3.5",
+            "nan": "2.6.2",
+            "node-gyp-build": "3.2.0"
           }
         },
         "ssb-keys": {
@@ -2369,9 +2368,9 @@
           "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.14.tgz",
           "integrity": "sha512-iZJ1DlV+cO+tIst7uM6xJsE8p4813KEKwPyDN0ZGyu5QpHY9DyeTmrvpp1rVxQMSZ2rBu/UMaZwtpAbCspT9pQ==",
           "requires": {
-            "chloride": "^2.2.8",
-            "mkdirp": "~0.5.0",
-            "private-box": "^0.2.1"
+            "chloride": "2.2.9",
+            "mkdirp": "0.5.1",
+            "private-box": "0.2.1"
           }
         }
       }
@@ -2381,11 +2380,11 @@
       "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.12.tgz",
       "integrity": "sha512-5K2rx7QLBOz/JFAWGevU0JsoeC/0PZufSFJPqxQefZSdhMmB2aO16CJ9rwfnAzwMZMGrM+F2/ljXTP9wHp4GlA==",
       "requires": {
-        "chloride": "^2.2.7",
-        "deep-equal": "~1.0.0",
-        "pull-box-stream": "^1.0.13",
-        "pull-handshake": "^1.1.1",
-        "pull-stream": "^3.4.5"
+        "chloride": "2.2.7",
+        "deep-equal": "1.0.1",
+        "pull-box-stream": "1.0.13",
+        "pull-handshake": "1.1.4",
+        "pull-stream": "3.6.0"
       }
     },
     "separator-escape": {
@@ -2398,7 +2397,7 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
       "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "shallow-copy": {
@@ -2412,9 +2411,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
       },
       "dependencies": {
         "glob": {
@@ -2423,12 +2422,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -2437,7 +2436,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -2473,8 +2472,8 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
       "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
       "requires": {
-        "ip": "^1.1.2",
-        "smart-buffer": "^1.0.4"
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
       }
     },
     "sodium-browserify": {
@@ -2482,9 +2481,9 @@
       "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.1.tgz",
       "integrity": "sha1-sLVZyjaYFnkIUhSFXiZkXfZ6rxw=",
       "requires": {
-        "libsodium-wrappers": "^0.2.9",
+        "libsodium-wrappers": "0.2.12",
         "sha.js": "2.4.5",
-        "tweetnacl": "^0.14.1"
+        "tweetnacl": "0.14.5"
       }
     },
     "sodium-browserify-tweetnacl": {
@@ -2492,11 +2491,11 @@
       "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
       "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
       "requires": {
-        "chloride-test": "^1.1.0",
-        "ed2curve": "^0.1.4",
-        "sha.js": "^2.4.8",
-        "tweetnacl": "^0.14.1",
-        "tweetnacl-auth": "^0.3.0"
+        "chloride-test": "1.2.2",
+        "ed2curve": "0.1.4",
+        "sha.js": "2.4.8",
+        "tweetnacl": "0.14.5",
+        "tweetnacl-auth": "0.3.1"
       },
       "dependencies": {
         "sha.js": {
@@ -2504,7 +2503,7 @@
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
           "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
           "requires": {
-            "inherits": "^2.0.1"
+            "inherits": "2.0.3"
           }
         }
       }
@@ -2520,8 +2519,8 @@
       "integrity": "sha1-lYdmk7M2xR1Kmk6hzMegSLuz43M=",
       "optional": true,
       "requires": {
-        "nan": "^2.4.0",
-        "node-gyp-build": "^3.0.0"
+        "nan": "2.6.2",
+        "node-gyp-build": "3.2.0"
       }
     },
     "sorted-array-functions": {
@@ -2535,7 +2534,7 @@
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "optional": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "amdefine": "1.0.1"
       }
     },
     "source-map-support": {
@@ -2543,7 +2542,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.6"
       },
       "dependencies": {
         "source-map": {
@@ -2569,8 +2568,8 @@
       "resolved": "https://registry.npmjs.org/ssb-about/-/ssb-about-0.1.2.tgz",
       "integrity": "sha512-/dvDJZdvukOHTjWDAUDdi5euG3fHIgW0z8xIWI+n+C3ugDCPad24josbRBMtgJ6e5piKOzstTlumIqfekvv8YQ==",
       "requires": {
-        "flumeview-reduce": "^1.3.9",
-        "ssb-ref": "^2.7.1"
+        "flumeview-reduce": "1.3.13",
+        "ssb-ref": "2.11.0"
       },
       "dependencies": {
         "async-single": {
@@ -2588,13 +2587,13 @@
           "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.13.tgz",
           "integrity": "sha512-QN/07+ia3uXpfy8/xWjLI2XGIG67Aiwp9VaOTIqYt6NHP6OfdGfl8nGRPkJRHlkfFbzEouRvJcQBFohWEXMdNQ==",
           "requires": {
-            "async-single": "^1.0.5",
-            "atomic-file": "^1.1.3",
-            "deep-equal": "^1.0.1",
+            "async-single": "1.0.5",
+            "atomic-file": "1.1.4",
+            "deep-equal": "1.0.1",
             "flumecodec": "0.0.0",
             "obv": "0.0.0",
-            "pull-notify": "^0.1.1",
-            "pull-stream": "^3.5.0"
+            "pull-notify": "0.1.1",
+            "pull-stream": "3.6.0"
           }
         },
         "obv": {
@@ -2609,14 +2608,14 @@
       "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.5.2.tgz",
       "integrity": "sha1-aBnyPwrBz/O6MfOsr0NAzG6SwZ8=",
       "requires": {
-        "explain-error": "^1.0.1",
-        "multicb": "^1.2.1",
-        "multiserver": "^1.7.0",
-        "muxrpc": "^6.3.3",
-        "pull-hash": "^1.0.0",
-        "pull-stream": "^3.6.0",
-        "ssb-config": "^2.0.0",
-        "ssb-keys": "^7.0.13"
+        "explain-error": "1.0.4",
+        "multicb": "1.2.2",
+        "multiserver": "1.10.0",
+        "muxrpc": "6.3.3",
+        "pull-hash": "1.0.0",
+        "pull-stream": "3.6.0",
+        "ssb-config": "2.2.0",
+        "ssb-keys": "7.0.13"
       },
       "dependencies": {
         "chloride": {
@@ -2624,11 +2623,11 @@
           "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.8.tgz",
           "integrity": "sha1-6/mos8qJp0R8NgOW2t+BfIqY1Zk=",
           "requires": {
-            "is-electron": "^2.0.0",
-            "sodium-browserify": "^1.0.3",
-            "sodium-browserify-tweetnacl": "^0.2.0",
-            "sodium-chloride": "^1.1.0",
-            "sodium-native": "^2.0.0"
+            "is-electron": "2.0.0",
+            "sodium-browserify": "1.2.1",
+            "sodium-browserify-tweetnacl": "0.2.3",
+            "sodium-chloride": "1.1.0",
+            "sodium-native": "2.0.1"
           }
         },
         "sodium-native": {
@@ -2637,8 +2636,8 @@
           "integrity": "sha512-3xi2SbjeEUivlH4zPaBIaxQtpAInq4T3zX9kaeDquzgXRv96QLbTR0AcJeqXj3JeKdhwJ6YiLS3XFrnMp4tc+w==",
           "optional": true,
           "requires": {
-            "nan": "^2.4.0",
-            "node-gyp-build": "^3.0.0"
+            "nan": "2.6.2",
+            "node-gyp-build": "3.2.0"
           }
         },
         "ssb-keys": {
@@ -2646,9 +2645,9 @@
           "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.13.tgz",
           "integrity": "sha1-nWUnEAWHawfOqie3JICPDGAQu8k=",
           "requires": {
-            "chloride": "^2.2.8",
-            "mkdirp": "~0.5.0",
-            "private-box": "^0.2.1"
+            "chloride": "2.2.8",
+            "mkdirp": "0.5.1",
+            "private-box": "0.2.1"
           }
         }
       }
@@ -2658,10 +2657,10 @@
       "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.2.0.tgz",
       "integrity": "sha1-QcrQOKhXWvQGLT/VfTsWe+hbA7w=",
       "requires": {
-        "deep-extend": "^0.4.0",
-        "non-private-ip": "^1.2.1",
-        "os-homedir": "^1.0.1",
-        "rc": "^1.1.6"
+        "deep-extend": "0.4.2",
+        "non-private-ip": "1.4.2",
+        "os-homedir": "1.0.2",
+        "rc": "1.2.1"
       }
     },
     "ssb-feed": {
@@ -2669,11 +2668,11 @@
       "resolved": "https://registry.npmjs.org/ssb-feed/-/ssb-feed-2.3.0.tgz",
       "integrity": "sha1-uE6OApeg9ZBMTPWiAvdroeB40Ec=",
       "requires": {
-        "cont": "~1.0.3",
-        "monotonic-timestamp": "~0.0.9",
-        "pull-stream": "^3.4.2",
-        "ssb-keys": "^7.0.0",
-        "ssb-ref": "^2.0.0"
+        "cont": "1.0.3",
+        "monotonic-timestamp": "0.0.9",
+        "pull-stream": "3.6.0",
+        "ssb-keys": "7.0.9",
+        "ssb-ref": "2.11.0"
       }
     },
     "ssb-friends": {
@@ -2681,13 +2680,13 @@
       "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-2.2.3.tgz",
       "integrity": "sha512-2SVderWO/xtF11uCPk00Zq+ZkXvb62ao077aTUuiXLroexW+H8qrXoumasrfODQbz9yZaMFol2T3KYPxLd3/mg==",
       "requires": {
-        "flumeview-reduce": "^1.3.0",
-        "graphreduce": "^3.0.3",
+        "flumeview-reduce": "1.3.3",
+        "graphreduce": "3.0.4",
         "obv": "0.0.1",
-        "pull-cont": "^0.1.1",
+        "pull-cont": "0.1.1",
         "pull-flatmap": "0.0.1",
-        "pull-stream": "^3.6.0",
-        "ssb-ref": "^2.7.1"
+        "pull-stream": "3.6.0",
+        "ssb-ref": "2.11.0"
       }
     },
     "ssb-keys": {
@@ -2695,9 +2694,9 @@
       "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.9.tgz",
       "integrity": "sha1-BrbrV3hHVyZs7RqMbQd8+BoIJfg=",
       "requires": {
-        "chloride": "^2.2.7",
-        "mkdirp": "~0.5.0",
-        "private-box": "^0.2.1"
+        "chloride": "2.2.7",
+        "mkdirp": "0.5.1",
+        "private-box": "0.2.1"
       }
     },
     "ssb-markdown": {
@@ -2705,10 +2704,10 @@
       "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-3.6.0.tgz",
       "integrity": "sha512-WaI/s6Zbq9EBAE9CD2OnPMn1U7Wce3HBK3EZN2qfnjIEkirL/oj8Wz92sBYyyV+tae1aJJRTV7/PFbT5YfNk+g==",
       "requires": {
-        "emoji-named-characters": "^1.0.2",
-        "ssb-marked": "^0.7.3",
-        "ssb-msgs": "^5.2.0",
-        "ssb-ref": "^2.3.0"
+        "emoji-named-characters": "1.0.2",
+        "ssb-marked": "0.7.4",
+        "ssb-msgs": "5.2.0",
+        "ssb-ref": "2.11.0"
       }
     },
     "ssb-marked": {
@@ -2721,7 +2720,7 @@
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
       "requires": {
-        "ssb-ref": "^2.0.0"
+        "ssb-ref": "2.11.0"
       }
     },
     "ssb-ref": {
@@ -2729,8 +2728,8 @@
       "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.0.tgz",
       "integrity": "sha512-PbL/eBYydMEeyTDQDkMuHg2pvdmSnWidRI7Qu8kSlbGKzT43Ltv/bxoL3mGUTH378llMKhwNs0otxDLg/WHxzQ==",
       "requires": {
-        "ip": "^1.1.3",
-        "is-valid-domain": "~0.0.1"
+        "ip": "1.1.5",
+        "is-valid-domain": "0.0.5"
       }
     },
     "ssb-sort": {
@@ -2738,7 +2737,7 @@
       "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-1.0.0.tgz",
       "integrity": "sha1-jplW9QdS0rFYJHsG5Jw/SRwc0ns=",
       "requires": {
-        "ssb-ref": "^2.3.0"
+        "ssb-ref": "2.11.0"
       }
     },
     "standard": {
@@ -2747,13 +2746,13 @@
       "integrity": "sha1-Y1Eyvnv7VnwpIQBfMPnjUOR1Kq0=",
       "dev": true,
       "requires": {
-        "eslint": "~3.10.2",
+        "eslint": "3.10.2",
         "eslint-config-standard": "6.2.1",
         "eslint-config-standard-jsx": "3.2.0",
-        "eslint-plugin-promise": "~3.4.0",
-        "eslint-plugin-react": "~6.7.1",
-        "eslint-plugin-standard": "~2.0.1",
-        "standard-engine": "~5.2.0"
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-react": "6.7.1",
+        "eslint-plugin-standard": "2.0.1",
+        "standard-engine": "5.2.0"
       }
     },
     "standard-engine": {
@@ -2762,12 +2761,12 @@
       "integrity": "sha1-QAZgrlrM6K/U22D/IhSpGQrXkKM=",
       "dev": true,
       "requires": {
-        "deglob": "^2.0.0",
-        "find-root": "^1.0.0",
-        "get-stdin": "^5.0.1",
-        "home-or-tmp": "^2.0.0",
-        "minimist": "^1.1.0",
-        "pkg-config": "^1.0.1"
+        "deglob": "2.1.0",
+        "find-root": "1.0.0",
+        "get-stdin": "5.0.1",
+        "home-or-tmp": "2.0.0",
+        "minimist": "1.2.0",
+        "pkg-config": "1.1.1"
       },
       "dependencies": {
         "minimist": {
@@ -2783,7 +2782,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
       "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
       "requires": {
-        "escodegen": "~0.0.24"
+        "escodegen": "0.0.28"
       },
       "dependencies": {
         "escodegen": {
@@ -2791,9 +2790,9 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
           "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
           "requires": {
-            "esprima": "~1.0.2",
-            "estraverse": "~1.3.0",
-            "source-map": ">= 0.1.2"
+            "esprima": "1.0.4",
+            "estraverse": "1.3.2",
+            "source-map": "0.1.43"
           }
         },
         "esprima": {
@@ -2813,17 +2812,17 @@
       "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.2.tgz",
       "integrity": "sha1-Mp+58iOlZiZr2nGEO32TLHZxdPM=",
       "requires": {
-        "concat-stream": "~1.6.0",
-        "duplexer2": "~0.0.2",
-        "escodegen": "~1.3.2",
-        "falafel": "^1.0.0",
-        "has": "^1.0.0",
-        "object-inspect": "~0.4.0",
-        "quote-stream": "~0.0.0",
-        "readable-stream": "~1.0.27-1",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "~0.2.0",
-        "through2": "~0.4.1"
+        "concat-stream": "1.6.0",
+        "duplexer2": "0.0.2",
+        "escodegen": "1.3.3",
+        "falafel": "1.2.0",
+        "has": "1.0.1",
+        "object-inspect": "0.4.0",
+        "quote-stream": "0.0.0",
+        "readable-stream": "1.0.34",
+        "shallow-copy": "0.0.1",
+        "static-eval": "0.2.4",
+        "through2": "0.4.2"
       },
       "dependencies": {
         "isarray": {
@@ -2836,10 +2835,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -2859,8 +2858,8 @@
       "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
       "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
       "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "looper": "3.0.0",
+        "pull-stream": "3.6.0"
       }
     },
     "string-width": {
@@ -2869,9 +2868,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -2879,7 +2878,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
       "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
       "requires": {
-        "safe-buffer": "~5.0.1"
+        "safe-buffer": "5.0.1"
       }
     },
     "strip-ansi": {
@@ -2887,7 +2886,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -2912,12 +2911,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "string-width": "2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2932,8 +2931,8 @@
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^3.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -2955,8 +2954,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
       "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
       "requires": {
-        "readable-stream": "~1.0.17",
-        "xtend": "~2.1.1"
+        "readable-stream": "1.0.34",
+        "xtend": "2.1.2"
       },
       "dependencies": {
         "isarray": {
@@ -2974,10 +2973,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -2990,7 +2989,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "~0.4.0"
+            "object-keys": "0.4.0"
           }
         }
       }
@@ -3021,7 +3020,7 @@
       "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
       "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
       "requires": {
-        "tweetnacl": "0.x.x"
+        "tweetnacl": "0.14.5"
       }
     },
     "type-check": {
@@ -3030,7 +3029,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
@@ -3055,7 +3054,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "util-deprecate": {
@@ -3081,7 +3080,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "ws": {
@@ -3089,8 +3088,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchcore",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "minimal core for ssb clients",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The background to this is that I realised the live pull-streams for chess games were not being aborted. This means that every time a chess game, or the miniboards for the chess games are viewed, there is a pull stream left dangling (which is a resource link.) This can add up to hundreds quite quickly as you flick between your games and game tabs.

I followed the example of `patchcore/backlinks/obs.js` to use a cache for the observables and abort the underlying pull stream if nobody subscribes to the observable for the backlinks for a given amount of time.

*Note*: I created `obs-cache.js` to avoid code duplication from `obs.js` in `obs-filter.js`, but I haven't refactored `obs.js` to use it yet. 

I was kind of nervous about touching it as it's very core to patchwork / patchbay and I wanted to check people were happy for me to refactor it. I know that the obs.filter file is only used by ssb-chess on the other hand (since I added it to patchcore for ssb-chess.)

If people are happy for me to do so I can update this pull request with obs.js refactored to use the cache or we can do it as a follow up request once my changes have been seen to be stable in ssb-chess for a while.