### PR TITLE
Default `{ private: true }` on `sbot.async.get()`

### DIFF
--- a/sbot.js
+++ b/sbot.js
@@ -153,7 +153,7 @@ exports.create = function (api) {
           }
           if (cache[key]) cb(null, cache[key])
           else {
-            sbot.get(key, function (err, value) {
+            sbot.get({ id: key, private: true }, function (err, value) {
               if (err) return cb(err)
               runHooks({key, value})
               cb(null, value)


### PR DESCRIPTION
After the changes to secure-scuttlebutt, other unboxers may make modifications to a message *without* being related to unboxing or private messages. This commit ensures that these modifications are passed through to the client correctly, without having to attempt unboxing each message one-by-one.

See: https://github.com/ssbc/secure-scuttlebutt/pull/228

cc: @ahdinosaur @mixmix are there any scenarios where we specifically want to avoid `{ private: true }` by default here?