### PR TITLE
Use unicode emoji instead of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ or _the shared assumptions of all (or most) ssb related applications_
 
 here's a list of apps in the wild using `patchcore`:
 
-- [`patchwork`](https://github.com/ssbc/patchwork)
 - [`patchbay`](https://github.com/ssbc/patchbay)
 - [`patchlite`](https://github.com/ssbc/patchlite)
 - [(add yours here)](https://github.com/ssbc/patchcore/edit/master/README.md)

--- a/message/html/markdown.js
+++ b/message/html/markdown.js
@@ -5,6 +5,7 @@ const nest = require('depnest')
 var htmlEscape = require('html-escape')
 var watch = require('mutant/watch')
 const querystring = require('querystring')
+const nodeEmoji = require('node-emoji')
 
 exports.needs = nest({
   'blob.sync.url': 'first',
@@ -46,10 +47,13 @@ exports.create = function (api) {
       ],
       innerHTML: renderer.block(content.text, {
         emoji: (emoji) => {
-          var url = emojiMentions[emoji]
-            ? api.blob.sync.url(emojiMentions[emoji])
-            : api.emoji.sync.url(emoji)
-          return renderEmoji(emoji, url)
+          if (emojiMentions[emoji]) {
+            return renderEmoji(emoji, api.blob.sync.url(emojiMentions[emoji]))
+          } else {
+            // https://github.com/omnidan/node-emoji/issues/76
+            const emojiCharacter = nodeEmoji.get(emoji).replace(/:/g, '')
+            return `<span class="emoji">${emojiCharacter}</span>`
+          }
         },
         toUrl: (id) => {
           var link = ref.parseLink(id)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "human-time": "0.0.1",
     "mutant": "^3.21.2",
     "mutant-pull-reduce": "^1.1.0",
+    "node-emoji": "^1.10.0",
     "pull-abortable": "^4.1.0",
     "pull-cat": "^1.1.11",
     "pull-defer": "~0.2.2",


### PR DESCRIPTION
Part of fixing https://github.com/ssbc/patchbay/issues/360 for patchbay

Other pr https://github.com/ssbc/patchbay/pull/361

I'm not sure I fully understand this (patchbay used the noto font before to render font emoji, but patchcore rendered stuff as images anyway?) but stuff seems to be working now so :man_shrugging: 

Does this break some other client?